### PR TITLE
fix(test): add required schema fields to contacts test

### DIFF
--- a/convex/contacts.test.ts
+++ b/convex/contacts.test.ts
@@ -1,14 +1,8 @@
-
 import { convexTest } from "convex-test";
 import { describe, it, expect, beforeEach } from "vitest";
 import { api } from "./_generated/api";
 import schema from "./schema";
-import { modules } from "./test.modules"; // We need to generate this or use import.meta.glob if using vite?
-// convex-test usually requires t.ts to setup
-
-// Actually, convex-test needs to bundle modules. 
-// A simpler way without full setup might be tricky.
-// Let's assume standard convex-test usage.
+import { modules } from "./test.modules";
 
 describe("Contacts", () => {
     let t: any;
@@ -18,21 +12,46 @@ describe("Contacts", () => {
     });
 
     it("should create contacts in batch", async () => {
-        // 1. Setup Identity
-        const realUserId = await t.run(async (ctx: any) => {
-            return await ctx.db.insert("users", { email: "test@example.com", name: "Test User" });
+        // 1. Setup: create user, organization, membership, and session
+        const { userId } = await t.run(async (ctx: any) => {
+            const userId = await ctx.db.insert("users", {
+                email: "test@example.com",
+                name: "Test User",
+            });
+            const orgId = await ctx.db.insert("organizations", {
+                name: "Test Org",
+                slug: "test-org",
+                ownerId: userId,
+                plan: "FREE",
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+            });
+            await ctx.db.insert("memberships", {
+                userId,
+                organizationId: orgId,
+                role: "OWNER",
+                status: "ONLINE",
+                maxConversations: 10,
+                activeConversations: 0,
+                lastSeenAt: Date.now(),
+                joinedAt: Date.now(),
+            });
+            await ctx.db.insert("userSessions", {
+                userId,
+                currentOrganizationId: orgId,
+                lastActivityAt: Date.now(),
+            });
+            return { userId, orgId };
         });
-
-        await t.withIdentity({ subject: realUserId }).mutation(api.sessions.ensure, {});
 
         // 2. Call batchCreate
         const contactsData = [
             { phone: "+221770000001", firstName: "Import", lastName: "One", tags: ["Imported"] },
-            { phone: "+221770000002", firstName: "Import", lastName: "Two", tags: ["Imported", "VIP"] }
+            { phone: "+221770000002", firstName: "Import", lastName: "Two", tags: ["Imported", "VIP"] },
         ];
 
-        const result = await t.withIdentity({ subject: realUserId }).mutation(api.contacts.batchCreate, {
-            contacts: contactsData
+        const result = await t.withIdentity({ subject: userId }).mutation(api.contacts.batchCreate, {
+            contacts: contactsData,
         });
 
         // 3. Verify Result
@@ -40,8 +59,8 @@ describe("Contacts", () => {
         expect(result.errors).toHaveLength(0);
 
         // 4. Verify Database
-        const contacts = await t.withIdentity({ subject: realUserId }).query(api.contacts.list, {
-            paginationOpts: { numItems: 10, cursor: null }
+        const contacts = await t.withIdentity({ subject: userId }).query(api.contacts.list, {
+            paginationOpts: { numItems: 10, cursor: null },
         });
 
         expect(contacts.page).toHaveLength(2);


### PR DESCRIPTION
## Summary
- Add missing required fields (`plan`, `createdAt`, `updatedAt`, `joinedAt`) to test fixtures
- Fixes "No active organization" and validator errors in CI

## Test plan
- [x] Verified test passes locally
- [ ] Verify CI passes