### PR TITLE
fix(schema): add trialUsed field to organizations.stripe

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -35,6 +35,7 @@ import type * as invitations from "../invitations.js";
 import type * as lib_auth from "../lib/auth.js";
 import type * as lib_email from "../lib/email.js";
 import type * as lib_permissions from "../lib/permissions.js";
+import type * as lib_planLimits from "../lib/planLimits.js";
 import type * as lib_stripePlans from "../lib/stripePlans.js";
 import type * as lib_templateBuilder from "../lib/templateBuilder.js";
 import type * as lib_templateTypes from "../lib/templateTypes.js";
@@ -102,6 +103,7 @@ declare const fullApi: ApiFromModules<{
   "lib/auth": typeof lib_auth;
   "lib/email": typeof lib_email;
   "lib/permissions": typeof lib_permissions;
+  "lib/planLimits": typeof lib_planLimits;
   "lib/stripePlans": typeof lib_stripePlans;
   "lib/templateBuilder": typeof lib_templateBuilder;
   "lib/templateTypes": typeof lib_templateTypes;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -98,6 +98,7 @@ export default defineSchema({
             priceId: v.optional(v.string()),
             status: v.optional(v.string()), // active, canceled, past_due, trialing
             currentPeriodEnd: v.optional(v.number()),
+            trialUsed: v.optional(v.boolean()),
         })),
 
         // Fair Usage Policy (Limits)


### PR DESCRIPTION
## Summary
- Ajoute `trialUsed: v.optional(v.boolean())` au validateur `stripe` dans la table `organizations`
- Corrige l'erreur runtime : "Object contains extra field `trialUsed` that is not in the validator"

## Test plan
- [ ] Plus d'erreur de validation sur les documents organizations avec `trialUsed`