### PR TITLE
feat(campaigns): add 12 campaign management features

### DIFF
--- a/app/dashboard/campagnes/[broadcastId]/page.tsx
+++ b/app/dashboard/campagnes/[broadcastId]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React from 'react';
+import React, { useState } from 'react';
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { Id } from "@/convex/_generated/dataModel";
@@ -8,7 +8,21 @@ import { useParams, useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
-import { ArrowLeft, Send, CheckCircle, Eye, MessageSquare, Play, Calendar, Copy, XCircle } from 'lucide-react';
+import { Progress } from '@/components/ui/progress';
+import {
+    AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+    AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger
+} from '@/components/ui/alert-dialog';
+import {
+    Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription
+} from '@/components/ui/dialog';
+import {
+    Select, SelectContent, SelectItem, SelectTrigger, SelectValue
+} from '@/components/ui/select';
+import {
+    ArrowLeft, Send, CheckCircle, Eye, MessageSquare, Play, Calendar, Copy, XCircle,
+    Plus, RefreshCw, GitCompare
+} from 'lucide-react';
 import { toast } from 'sonner';
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
@@ -37,6 +51,26 @@ function ChartTooltip({ active, payload, label }: { active?: boolean; payload?: 
     );
 }
 
+const ACTIVITY_ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
+    created: Plus,
+    scheduled: Calendar,
+    sending_started: Play,
+    completed: CheckCircle,
+    failures: XCircle,
+    cancelled: XCircle,
+    retry: RefreshCw,
+};
+
+const ACTIVITY_COLOR_MAP: Record<string, string> = {
+    created: 'bg-green-500',
+    scheduled: 'bg-amber-500',
+    sending_started: 'bg-blue-500',
+    completed: 'bg-green-500',
+    failures: 'bg-red-500',
+    cancelled: 'bg-gray-500',
+    retry: 'bg-blue-500',
+};
+
 export default function BroadcastDetailsPage() {
     const params = useParams();
     const router = useRouter();
@@ -45,6 +79,25 @@ export default function BroadcastDetailsPage() {
     const broadcast = useQuery(api.broadcasts.get, { id: broadcastId });
     const updateBroadcast = useMutation(api.broadcasts.update);
     const duplicateBroadcast = useMutation(api.broadcasts.duplicate);
+    const retryFailedMutation = useMutation(api.broadcasts.retryFailed);
+
+    // Feature 2: Activity timeline
+    const activityData = useQuery(api.broadcasts.getActivity, { broadcastId });
+
+    // Feature 3: Confirmation dialog state
+    const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+
+    // Feature 4: Retry loading state
+    const [retryLoading, setRetryLoading] = useState(false);
+
+    // Feature 6: Campaign comparison
+    const [showCompareDialog, setShowCompareDialog] = useState(false);
+    const [compareId, setCompareId] = useState<string | null>(null);
+    const allBroadcasts = useQuery(api.broadcasts.list, {});
+    const compareBroadcast = useQuery(
+        api.broadcasts.get,
+        compareId ? { id: compareId as Id<"broadcasts"> } : "skip"
+    );
 
     const handleActivate = async () => {
         if (!broadcast) return;
@@ -80,6 +133,20 @@ export default function BroadcastDetailsPage() {
             router.push(`/dashboard/campagnes/${newId}`);
         } catch {
             toast.error("Erreur lors de la duplication");
+        }
+    };
+
+    // Feature 4: Retry failed handler
+    const handleRetryFailed = async () => {
+        if (!broadcast) return;
+        setRetryLoading(true);
+        try {
+            const result = await retryFailedMutation({ broadcastId });
+            toast.success(`${result.retriedCount} messages relancés`);
+        } catch {
+            toast.error("Erreur lors de la relance");
+        } finally {
+            setRetryLoading(false);
         }
     };
 
@@ -141,6 +208,9 @@ export default function BroadcastDetailsPage() {
     const deliveryRate = broadcast.sentCount > 0 ? Math.round((broadcast.deliveredCount / broadcast.sentCount) * 100) : 0;
     const openRate = broadcast.deliveredCount > 0 ? Math.round((broadcast.readCount / broadcast.deliveredCount) * 100) : 0;
     const replyRate = broadcast.readCount > 0 ? Math.round((broadcast.repliedCount / broadcast.readCount) * 100) : 0;
+
+    // Feature 1: Progress calculation
+    const progress = broadcast.totalAudience > 0 ? Math.round((broadcast.sentCount / broadcast.totalAudience) * 100) : 0;
 
     const getStatusConfig = (status: string) => {
         switch (status) {
@@ -205,33 +275,95 @@ export default function BroadcastDetailsPage() {
                                 {statusConfig.label}
                             </span>
                         </div>
+                        {/* Feature 5: Show channel used */}
                         <p className="text-sm text-gray-500 mt-0.5">
                             Template: <span className="font-medium text-gray-700">{broadcast.template?.name || 'Inconnu'}</span>
                             {' '}&middot;{' '}
                             Créée le {format(new Date(broadcast.createdAt), 'dd MMMM yyyy à HH:mm', { locale: fr })}
+                            {broadcast.channelName && (
+                                <>
+                                    {' '}&middot;{' '}
+                                    Canal: <span className="font-medium text-gray-700">{broadcast.channelName}</span>
+                                </>
+                            )}
                         </p>
                     </div>
-                    <div className="flex items-center gap-2">
+                    <div className="flex items-center gap-2 flex-wrap">
+                        {/* Feature 6: Compare button */}
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setShowCompareDialog(true)}
+                            className="h-8 gap-1.5 text-xs rounded-full cursor-pointer"
+                        >
+                            <GitCompare className="h-3.5 w-3.5" />
+                            Comparer
+                        </Button>
                         <Button variant="outline" size="sm" onClick={handleDuplicate} className="h-8 gap-1.5 text-xs rounded-full cursor-pointer">
                             <Copy className="h-3.5 w-3.5" />
                             Dupliquer
                         </Button>
-                        {broadcast.status === 'DRAFT' && (
+                        {/* Feature 4: Retry failed button */}
+                        {broadcast.failedCount > 0 && (
                             <Button
+                                variant="outline"
                                 size="sm"
-                                onClick={handleActivate}
-                                className="h-8 gap-1.5 text-xs rounded-full cursor-pointer"
+                                onClick={handleRetryFailed}
+                                disabled={retryLoading}
+                                className="h-8 gap-1.5 text-xs rounded-full cursor-pointer text-orange-600 border-orange-200 hover:bg-orange-50 hover:text-orange-700"
                             >
-                                {broadcast.scheduledAt ? (
-                                    <>
-                                        <Calendar className="h-3.5 w-3.5" /> Activer la planification
-                                    </>
-                                ) : (
-                                    <>
-                                        <Play className="h-3.5 w-3.5" /> Envoyer maintenant
-                                    </>
-                                )}
+                                <RefreshCw className={cn("h-3.5 w-3.5", retryLoading && "animate-spin")} />
+                                {retryLoading ? 'Relance...' : 'Relancer les échecs'}
                             </Button>
+                        )}
+                        {/* Feature 3: Confirmation dialog before sending */}
+                        {broadcast.status === 'DRAFT' && (
+                            <AlertDialog open={showConfirmDialog} onOpenChange={setShowConfirmDialog}>
+                                <AlertDialogTrigger asChild>
+                                    <Button
+                                        size="sm"
+                                        className="h-8 gap-1.5 text-xs rounded-full cursor-pointer"
+                                    >
+                                        {broadcast.scheduledAt ? (
+                                            <>
+                                                <Calendar className="h-3.5 w-3.5" /> Activer la planification
+                                            </>
+                                        ) : (
+                                            <>
+                                                <Play className="h-3.5 w-3.5" /> Envoyer maintenant
+                                            </>
+                                        )}
+                                    </Button>
+                                </AlertDialogTrigger>
+                                <AlertDialogContent>
+                                    <AlertDialogHeader>
+                                        <AlertDialogTitle>Confirmer l&apos;envoi</AlertDialogTitle>
+                                        <AlertDialogDescription asChild>
+                                            <div className="space-y-2 text-sm text-gray-600">
+                                                <p>Vous allez lancer cette campagne :</p>
+                                                <ul className="space-y-1.5 ml-1">
+                                                    <li><span className="font-medium text-gray-800">Campagne :</span> {broadcast.name}</li>
+                                                    <li><span className="font-medium text-gray-800">Template :</span> {broadcast.template?.name || 'Inconnu'}</li>
+                                                    <li><span className="font-medium text-gray-800">Audience estimée :</span> {broadcast.totalAudience} contacts</li>
+                                                    <li><span className="font-medium text-gray-800">Canal :</span> {broadcast.channelName || 'Par défaut'}</li>
+                                                </ul>
+                                            </div>
+                                        </AlertDialogDescription>
+                                    </AlertDialogHeader>
+                                    <AlertDialogFooter>
+                                        <AlertDialogCancel className="cursor-pointer">Annuler</AlertDialogCancel>
+                                        <AlertDialogAction
+                                            onClick={() => {
+                                                setShowConfirmDialog(false);
+                                                handleActivate();
+                                            }}
+                                            className="bg-green-600 hover:bg-green-700 cursor-pointer"
+                                        >
+                                            Envoyer maintenant
+                                        </AlertDialogAction>
+                                    </AlertDialogFooter>
+                                </AlertDialogContent>
+                            </AlertDialog>
                         )}
                         {(broadcast.status === 'SCHEDULED' || broadcast.status === 'DRAFT') && (
                             <Button
@@ -246,6 +378,25 @@ export default function BroadcastDetailsPage() {
                     </div>
                 </div>
             </div>
+
+            {/* Feature 1: Real-time Progress Bar */}
+            {broadcast.status === 'SENDING' && (
+                <div className="bg-white border border-gray-100 rounded-lg p-4 shadow-sm">
+                    <div className="flex items-center gap-2 mb-2">
+                        <span className="relative flex h-2.5 w-2.5">
+                            <span className="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75" />
+                            <span className="relative inline-flex rounded-full h-2.5 w-2.5 bg-green-500" />
+                        </span>
+                        <span className="text-sm font-medium text-gray-700">
+                            Envoi en cours... {broadcast.sentCount}/{broadcast.totalAudience} ({progress}%)
+                        </span>
+                    </div>
+                    <Progress
+                        value={progress}
+                        className="h-3 bg-gray-100"
+                    />
+                </div>
+            )}
 
             {/* Metric Cards */}
             <div className="grid gap-4 grid-cols-2 lg:grid-cols-4">
@@ -358,6 +509,120 @@ export default function BroadcastDetailsPage() {
                     </CardContent>
                 </Card>
             </div>
+
+            {/* Feature 2: Activity Timeline */}
+            {activityData && activityData.activities.length > 0 && (
+                <Card className="bg-white border-gray-100 shadow-sm">
+                    <CardHeader className="pb-2">
+                        <CardTitle className="text-sm sm:text-base font-semibold text-gray-900">
+                            Historique d&apos;activité
+                        </CardTitle>
+                    </CardHeader>
+                    <CardContent className="pt-2 pb-4">
+                        <div className="relative">
+                            {/* Vertical line */}
+                            <div className="absolute left-[11px] top-2 bottom-2 w-0.5 bg-gray-200" />
+                            <div className="space-y-4">
+                                {activityData.activities.map((activity, index) => {
+                                    const IconComp = ACTIVITY_ICON_MAP[activity.type] || Plus;
+                                    const dotColor = ACTIVITY_COLOR_MAP[activity.type] || 'bg-gray-400';
+                                    return (
+                                        <div key={`${activity.type}-${index}`} className="flex items-start gap-3 relative">
+                                            <div className={cn("relative z-10 flex items-center justify-center h-6 w-6 rounded-full shrink-0", dotColor)}>
+                                                <IconComp className="h-3 w-3 text-white" />
+                                            </div>
+                                            <div className="flex-1 min-w-0 flex items-center justify-between gap-2">
+                                                <p className="text-sm text-gray-700 truncate">{activity.message}</p>
+                                                <time className="text-[11px] text-gray-400 whitespace-nowrap shrink-0">
+                                                    {format(new Date(activity.timestamp), "dd MMM yyyy 'à' HH:mm", { locale: fr })}
+                                                </time>
+                                            </div>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        </div>
+                    </CardContent>
+                </Card>
+            )}
+
+            {/* Feature 6: Campaign Comparison Dialog */}
+            <Dialog open={showCompareDialog} onOpenChange={setShowCompareDialog}>
+                <DialogContent className="sm:max-w-2xl">
+                    <DialogHeader>
+                        <DialogTitle>Comparer les campagnes</DialogTitle>
+                        <DialogDescription>
+                            Sélectionnez une campagne pour comparer les performances
+                        </DialogDescription>
+                    </DialogHeader>
+                    <div className="space-y-4">
+                        <Select
+                            value={compareId ?? ""}
+                            onValueChange={(val) => setCompareId(val || null)}
+                        >
+                            <SelectTrigger className="w-full">
+                                <SelectValue placeholder="Choisir une campagne..." />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {allBroadcasts?.filter(b => b._id !== broadcastId).map((b) => (
+                                    <SelectItem key={b._id} value={b._id}>
+                                        {b.name}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+
+                        {compareId && compareBroadcast && (
+                            <div className="overflow-x-auto">
+                                <table className="w-full text-sm">
+                                    <thead>
+                                        <tr className="border-b border-gray-200">
+                                            <th className="text-left py-2 px-3 font-medium text-gray-500">Métrique</th>
+                                            <th className="text-center py-2 px-3 font-medium text-gray-700">{broadcast.name}</th>
+                                            <th className="text-center py-2 px-3 font-medium text-gray-700">{compareBroadcast.name}</th>
+                                            <th className="text-center py-2 px-3 font-medium text-gray-500">Diff</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                        {[
+                                            { label: 'Envoyés', a: broadcast.sentCount, b: compareBroadcast.sentCount, higherIsBetter: true },
+                                            { label: 'Délivrés', a: broadcast.deliveredCount, b: compareBroadcast.deliveredCount, higherIsBetter: true },
+                                            { label: 'Lus', a: broadcast.readCount, b: compareBroadcast.readCount, higherIsBetter: true },
+                                            { label: 'Réponses', a: broadcast.repliedCount, b: compareBroadcast.repliedCount, higherIsBetter: true },
+                                            { label: 'Échecs', a: broadcast.failedCount, b: compareBroadcast.failedCount, higherIsBetter: false },
+                                        ].map((row) => {
+                                            const diff = row.a - row.b;
+                                            const isBetter = row.higherIsBetter ? diff > 0 : diff < 0;
+                                            const isWorse = row.higherIsBetter ? diff < 0 : diff > 0;
+                                            return (
+                                                <tr key={row.label} className="border-b border-gray-100">
+                                                    <td className="py-2.5 px-3 text-gray-600 font-medium">{row.label}</td>
+                                                    <td className="py-2.5 px-3 text-center font-semibold text-gray-900">{row.a}</td>
+                                                    <td className="py-2.5 px-3 text-center font-semibold text-gray-900">{row.b}</td>
+                                                    <td className={cn(
+                                                        "py-2.5 px-3 text-center font-semibold",
+                                                        isBetter && "text-green-600",
+                                                        isWorse && "text-red-600",
+                                                        diff === 0 && "text-gray-400"
+                                                    )}>
+                                                        {diff > 0 ? '+' : ''}{diff}
+                                                    </td>
+                                                </tr>
+                                            );
+                                        })}
+                                    </tbody>
+                                </table>
+                            </div>
+                        )}
+
+                        {compareId && compareBroadcast === undefined && (
+                            <div className="flex justify-center py-8">
+                                <Skeleton className="h-40 w-full rounded-lg" />
+                            </div>
+                        )}
+                    </div>
+                </DialogContent>
+            </Dialog>
         </div>
     );
 }

--- a/app/dashboard/campagnes/new/page.tsx
+++ b/app/dashboard/campagnes/new/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { useRouter } from 'next/navigation';
@@ -8,10 +8,11 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { ArrowLeft, Loader2, Plus, Phone } from 'lucide-react';
+import { ArrowLeft, Loader2, Plus, Phone, Users, Eye, MessageSquare } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Id } from '@/convex/_generated/dataModel';
 import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
 import { useChannels } from '@/hooks/useChannels';
 import { Switch } from '@/components/ui/switch';
 import { Calendar as CalendarIcon } from 'lucide-react';
@@ -43,6 +44,25 @@ export default function NewBroadcastPage() {
     const [isScheduled, setIsScheduled] = useState(false);
     const [date, setDate] = useState<Date>();
     const [time, setTime] = useState<string>("09:00");
+
+    // Audience estimation config
+    const audienceConfig = useMemo(() => {
+        if (audienceType === 'TAGS') {
+            return { type: "TAGS" as const, tags: selectedTags as Id<"tags">[] };
+        }
+        if (audienceType === 'COUNTRIES') {
+            return { type: "COUNTRIES" as const, countries: selectedCountries };
+        }
+        return { type: "ALL" as const };
+    }, [audienceType, selectedTags, selectedCountries]);
+
+    const audienceEstimate = useQuery(api.broadcasts.estimateAudience, { audienceConfig });
+
+    // Selected template for preview
+    const selectedTemplate = useMemo(() => {
+        if (!templateId || !templates) return null;
+        return templates.find(t => t._id === templateId) ?? null;
+    }, [templateId, templates]);
 
     const toggleTag = (tagId: string) => {
         setSelectedTags(prev =>
@@ -232,6 +252,21 @@ export default function NewBroadcastPage() {
                                     )}
                                 </div>
                             )}
+
+                            {/* Audience Estimation */}
+                            {audienceEstimate === undefined ? (
+                                <div className="flex items-center gap-2 rounded-lg bg-green-50 border border-green-100 px-3 py-2">
+                                    <Users className="h-4 w-4 text-green-600" />
+                                    <Skeleton className="h-4 w-32" />
+                                </div>
+                            ) : (
+                                <div className="flex items-center gap-2 rounded-lg bg-green-50 border border-green-100 px-3 py-2">
+                                    <Users className="h-4 w-4 text-green-600" />
+                                    <span className="text-sm text-green-700">
+                                        ~<span className="font-bold">{audienceEstimate.count}</span> contacts ciblés
+                                    </span>
+                                </div>
+                            )}
                         </div>
 
                         {/* Channel selector */}
@@ -301,6 +336,66 @@ export default function NewBroadcastPage() {
                                 </Button>
                             </div>
                         </div>
+
+                        {/* Template Preview */}
+                        {selectedTemplate && (
+                            <Card className="border-gray-100 bg-gray-50/50 shadow-none">
+                                <CardHeader className="pb-3">
+                                    <CardTitle className="text-sm font-semibold text-gray-900 flex items-center gap-2">
+                                        <Eye className="h-4 w-4 text-green-600" />
+                                        Aperçu du message
+                                    </CardTitle>
+                                </CardHeader>
+                                <CardContent>
+                                    <div className="flex justify-start">
+                                        <div className="relative max-w-sm w-full">
+                                            {/* WhatsApp bubble tail */}
+                                            <div className="absolute -left-2 top-0 w-0 h-0 border-t-[8px] border-t-[#dcf8c6] border-r-[8px] border-r-transparent" />
+                                            {/* Message bubble */}
+                                            <div className="rounded-lg rounded-tl-none bg-[#dcf8c6] p-3 space-y-2 shadow-sm">
+                                                {/* Header */}
+                                                {selectedTemplate.header?.type && selectedTemplate.header?.text && (
+                                                    <div className="font-semibold text-sm text-gray-900">
+                                                        {selectedTemplate.header.text}
+                                                    </div>
+                                                )}
+                                                {selectedTemplate.header?.type && selectedTemplate.header?.mediaUrl && (
+                                                    <div className="rounded bg-gray-200/60 p-4 text-center text-xs text-gray-500">
+                                                        <MessageSquare className="h-6 w-6 mx-auto mb-1 text-gray-400" />
+                                                        {selectedTemplate.header.type === 'IMAGE' ? 'Image' : selectedTemplate.header.type === 'VIDEO' ? 'Vidéo' : 'Document'}
+                                                    </div>
+                                                )}
+                                                {/* Body */}
+                                                {selectedTemplate.body && (
+                                                    <p className="text-sm text-gray-800 whitespace-pre-wrap leading-relaxed">
+                                                        {selectedTemplate.body}
+                                                    </p>
+                                                )}
+                                                {/* Footer */}
+                                                {selectedTemplate.footer && (
+                                                    <p className="text-[11px] text-gray-500 italic">
+                                                        {selectedTemplate.footer}
+                                                    </p>
+                                                )}
+                                            </div>
+                                            {/* Buttons */}
+                                            {selectedTemplate.buttons && selectedTemplate.buttons.length > 0 && (
+                                                <div className="mt-1 space-y-1">
+                                                    {selectedTemplate.buttons.map((btn: { type: string; text: string }, idx: number) => (
+                                                        <div
+                                                            key={idx}
+                                                            className="w-full text-center py-1.5 text-sm font-medium text-blue-500 bg-white rounded-lg border border-gray-100 shadow-sm"
+                                                        >
+                                                            {btn.text}
+                                                        </div>
+                                                    ))}
+                                                </div>
+                                            )}
+                                        </div>
+                                    </div>
+                                </CardContent>
+                            </Card>
+                        )}
 
                         {/* Scheduling */}
                         <div className="space-y-4 rounded-lg border border-gray-100 p-4 bg-gray-50/50">

--- a/components/broadcasts/BroadcastList.tsx
+++ b/components/broadcasts/BroadcastList.tsx
@@ -1,16 +1,16 @@
 'use client'
 
-import React, { useState } from 'react';
+import React, { useState, useMemo, useCallback } from 'react';
 import { useQuery, useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
-import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { SearchInput } from '@/components/ui/search-input';
 import { Skeleton } from '@/components/ui/skeleton';
+import { Pagination } from '@/components/ui/pagination';
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
-import { MoreHorizontal, Plus, RadioTower, ExternalLink, Trash2, Copy, Send, CheckCircle, Eye, MessageSquare } from 'lucide-react';
+import { MoreHorizontal, Plus, RadioTower, ExternalLink, Trash2, Copy, Send, CheckCircle, Eye, MessageSquare, Download, Archive, ArrowUpDown } from 'lucide-react';
 import { useRouter } from 'next/navigation';
 import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from "sonner";
@@ -57,20 +57,145 @@ const STAT_GRADIENTS = [
     'from-[#14532d] to-[#34d399]',
 ];
 
+const STATUS_FILTERS = [
+    { value: "ALL", label: "Tous" },
+    { value: "DRAFT", label: "Brouillon" },
+    { value: "SCHEDULED", label: "Planifi\u00e9e" },
+    { value: "SENDING", label: "En cours" },
+    { value: "COMPLETED", label: "Termin\u00e9e" },
+    { value: "FAILED", label: "\u00c9chou\u00e9e" },
+    { value: "CANCELLED", label: "Annul\u00e9e" },
+];
+
+type SortOption = "newest" | "oldest" | "name_asc" | "best_rate";
+
+const SORT_OPTIONS: { value: SortOption; label: string }[] = [
+    { value: "newest", label: "Plus r\u00e9cente" },
+    { value: "oldest", label: "Plus ancienne" },
+    { value: "name_asc", label: "Nom A-Z" },
+    { value: "best_rate", label: "Meilleur taux" },
+];
+
+const ITEMS_PER_PAGE = 10;
+
+function exportBroadcastsCsv(broadcasts: Array<{
+    name: string;
+    status: string;
+    templateName: string;
+    channelName: string | null;
+    sentCount: number;
+    deliveredCount: number;
+    readCount: number;
+    repliedCount: number;
+    failedCount: number;
+    createdAt: number;
+}>) {
+    const headers = ["Nom", "Statut", "Template", "Canal", "Envoy\u00e9s", "D\u00e9livr\u00e9s", "Lus", "R\u00e9ponses", "\u00c9checs", "Date de cr\u00e9ation"];
+    const rows = broadcasts.map(b => [
+        `"${b.name.replace(/"/g, '""')}"`,
+        b.status,
+        `"${b.templateName.replace(/"/g, '""')}"`,
+        b.channelName || "Par d\u00e9faut",
+        b.sentCount,
+        b.deliveredCount,
+        b.readCount,
+        b.repliedCount,
+        b.failedCount,
+        format(new Date(b.createdAt), 'dd/MM/yyyy HH:mm', { locale: fr }),
+    ]);
+
+    const csv = [headers.join(","), ...rows.map(r => r.join(","))].join("\n");
+    const blob = new Blob(["\uFEFF" + csv], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `campagnes_export_${format(new Date(), 'yyyy-MM-dd')}.csv`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+}
+
 export const BroadcastList: React.FC = () => {
     const router = useRouter();
     const [searchTerm, setSearchTerm] = useState('');
     const [selectedRows, setSelectedRows] = useState<Set<string>>(new Set());
     const [broadcastToDelete, setBroadcastToDelete] = useState<string | null>(null);
+    const [statusFilter, setStatusFilter] = useState<string>("ALL");
+    const [sortBy, setSortBy] = useState<SortOption>("newest");
+    const [currentPage, setCurrentPage] = useState(1);
 
     const broadcasts = useQuery(api.broadcasts.list, { search: searchTerm || undefined });
     const duplicateBroadcast = useMutation(api.broadcasts.duplicate);
     const deleteBroadcast = useMutation(api.broadcasts.deleteBroadcast);
+    const archiveBroadcast = useMutation(api.broadcasts.archiveBroadcast);
+
+    // Reset page when filter/search/sort changes
+    const handleSearchChange = useCallback((value: string) => {
+        setSearchTerm(value);
+        setCurrentPage(1);
+    }, []);
+
+    const handleStatusFilterChange = useCallback((value: string) => {
+        setStatusFilter(value);
+        setCurrentPage(1);
+        setSelectedRows(new Set());
+    }, []);
+
+    const handleSortChange = useCallback((value: SortOption) => {
+        setSortBy(value);
+        setCurrentPage(1);
+    }, []);
+
+    // Filter by status
+    const filteredBroadcasts = useMemo(() => {
+        if (!broadcasts) return [];
+        if (statusFilter === "ALL") return broadcasts;
+        return broadcasts.filter(b => b.status === statusFilter);
+    }, [broadcasts, statusFilter]);
+
+    // Sort
+    const sortedBroadcasts = useMemo(() => {
+        const arr = [...filteredBroadcasts];
+        switch (sortBy) {
+            case "newest":
+                return arr.sort((a, b) => b.createdAt - a.createdAt);
+            case "oldest":
+                return arr.sort((a, b) => a.createdAt - b.createdAt);
+            case "name_asc":
+                return arr.sort((a, b) => a.name.localeCompare(b.name, 'fr'));
+            case "best_rate": {
+                const getRate = (b: typeof arr[number]) =>
+                    b.deliveredCount > 0 ? (b.readCount / b.deliveredCount) : 0;
+                return arr.sort((a, b) => getRate(b) - getRate(a));
+            }
+            default:
+                return arr;
+        }
+    }, [filteredBroadcasts, sortBy]);
+
+    // Pagination
+    const totalItems = sortedBroadcasts.length;
+    const totalPages = Math.max(1, Math.ceil(totalItems / ITEMS_PER_PAGE));
+    const safePage = Math.min(currentPage, totalPages);
+    const startIndex = (safePage - 1) * ITEMS_PER_PAGE;
+    const endIndex = Math.min(startIndex + ITEMS_PER_PAGE, totalItems);
+    const paginatedBroadcasts = sortedBroadcasts.slice(startIndex, endIndex);
+
+    // Status counts for tab badges
+    const statusCounts = useMemo(() => {
+        if (!broadcasts) return {} as Record<string, number>;
+        const counts: Record<string, number> = { ALL: broadcasts.length };
+        for (const b of broadcasts) {
+            counts[b.status] = (counts[b.status] || 0) + 1;
+        }
+        return counts;
+    }, [broadcasts]);
 
     const handleDuplicate = async (id: Id<"broadcasts">) => {
         try {
             const newId = await duplicateBroadcast({ id });
-            toast.success("Campagne dupliquée");
+            toast.success("Campagne dupliqu\u00e9e");
             router.push(`/dashboard/campagnes/${newId}`);
         } catch {
             toast.error("Erreur lors de la duplication");
@@ -80,7 +205,7 @@ export const BroadcastList: React.FC = () => {
     const handleDelete = async (id: string) => {
         try {
             await deleteBroadcast({ id: id as Id<"broadcasts"> });
-            toast.success("Campagne supprimée");
+            toast.success("Campagne supprim\u00e9e");
             setBroadcastToDelete(null);
             if (selectedRows.has(id)) {
                 const newSelected = new Set(selectedRows);
@@ -97,11 +222,49 @@ export const BroadcastList: React.FC = () => {
 
         try {
             await Promise.all(Array.from(selectedRows).map(id => deleteBroadcast({ id: id as Id<"broadcasts"> })));
-            toast.success(`${selectedRows.size} campagnes supprimées`);
+            toast.success(`${selectedRows.size} campagnes supprim\u00e9es`);
             setSelectedRows(new Set());
         } catch {
-            toast.error("Erreur lors de la suppression groupée");
+            toast.error("Erreur lors de la suppression group\u00e9e");
         }
+    };
+
+    const handleBatchDuplicate = async () => {
+        try {
+            await Promise.all(Array.from(selectedRows).map(id => duplicateBroadcast({ id: id as Id<"broadcasts"> })));
+            toast.success(`${selectedRows.size} campagnes dupliqu\u00e9es`);
+            setSelectedRows(new Set());
+        } catch {
+            toast.error("Erreur lors de la duplication group\u00e9e");
+        }
+    };
+
+    const handleBatchArchive = async () => {
+        const archivable = Array.from(selectedRows).filter(id => {
+            const b = broadcasts?.find(br => br._id === id);
+            return b && (b.status === "DRAFT" || b.status === "COMPLETED");
+        });
+
+        if (archivable.length === 0) {
+            toast.error("Seuls les brouillons et campagnes termin\u00e9es peuvent \u00eatre archiv\u00e9s");
+            return;
+        }
+
+        try {
+            await Promise.all(archivable.map(id => archiveBroadcast({ id: id as Id<"broadcasts"> })));
+            toast.success(`${archivable.length} campagnes archiv\u00e9es`);
+            setSelectedRows(new Set());
+        } catch {
+            toast.error("Erreur lors de l'archivage group\u00e9");
+        }
+    };
+
+    const handleExportCsv = () => {
+        if (!broadcasts) return;
+        const selected = broadcasts.filter(b => selectedRows.has(b._id));
+        if (selected.length === 0) return;
+        exportBroadcastsCsv(selected);
+        toast.success(`${selected.length} campagnes export\u00e9es`);
     };
 
     const toggleRow = (id: string) => {
@@ -115,11 +278,17 @@ export const BroadcastList: React.FC = () => {
     };
 
     const toggleAll = () => {
-        if (!broadcasts) return;
-        if (selectedRows.size === broadcasts.length) {
-            setSelectedRows(new Set());
+        if (paginatedBroadcasts.length === 0) return;
+        const allPageIds = paginatedBroadcasts.map(b => b._id);
+        const allSelected = allPageIds.every(id => selectedRows.has(id));
+        if (allSelected) {
+            const newSelected = new Set(selectedRows);
+            allPageIds.forEach(id => newSelected.delete(id));
+            setSelectedRows(newSelected);
         } else {
-            setSelectedRows(new Set(broadcasts.map(b => b._id)));
+            const newSelected = new Set(selectedRows);
+            allPageIds.forEach(id => newSelected.add(id));
+            setSelectedRows(newSelected);
         }
     };
 
@@ -130,10 +299,10 @@ export const BroadcastList: React.FC = () => {
     const totalReplied = broadcasts?.reduce((sum, b) => sum + b.repliedCount, 0) ?? 0;
 
     const summaryStats = [
-        { title: 'Envoyés', value: totalSent.toString(), icon: Send, gradient: STAT_GRADIENTS[0] },
-        { title: 'Délivrés', value: totalDelivered.toString(), icon: CheckCircle, gradient: STAT_GRADIENTS[1] },
+        { title: 'Envoy\u00e9s', value: totalSent.toString(), icon: Send, gradient: STAT_GRADIENTS[0] },
+        { title: 'D\u00e9livr\u00e9s', value: totalDelivered.toString(), icon: CheckCircle, gradient: STAT_GRADIENTS[1] },
         { title: 'Lus', value: totalRead.toString(), icon: Eye, gradient: STAT_GRADIENTS[2] },
-        { title: 'Réponses', value: totalReplied.toString(), icon: MessageSquare, gradient: STAT_GRADIENTS[3] },
+        { title: 'R\u00e9ponses', value: totalReplied.toString(), icon: MessageSquare, gradient: STAT_GRADIENTS[3] },
     ];
 
     if (broadcasts === undefined) {
@@ -162,49 +331,49 @@ export const BroadcastList: React.FC = () => {
         );
     }
 
-    if (broadcasts.length === 0 && !searchTerm) {
-        return (
-            <Card className="bg-white border-gray-100 shadow-sm">
-                <CardContent className="py-16">
-                    <Empty>
-                        <EmptyMedia variant="icon">
-                            <div className={cn("h-14 w-14 rounded-full bg-gradient-to-br flex items-center justify-center shadow-lg shadow-green-900/20", STAT_GRADIENTS[0])}>
-                                <RadioTower className="h-7 w-7 text-white" />
-                            </div>
-                        </EmptyMedia>
-                        <EmptyHeader>
-                            <EmptyTitle className="text-gray-900">Aucune campagne</EmptyTitle>
-                            <EmptyDescription className="text-gray-500">
-                                Créez votre première campagne de diffusion WhatsApp pour toucher vos clients.
-                            </EmptyDescription>
-                        </EmptyHeader>
-                        <div className="mt-4">
-                            <Button
-                                size="sm"
-                                onClick={() => router.push('/dashboard/campagnes/new')}
-                                className="h-8 gap-1.5 text-xs rounded-full cursor-pointer"
-                            >
-                                <Plus className="h-3.5 w-3.5" />
-                                Nouvelle Campagne
-                            </Button>
-                        </div>
-                    </Empty>
-                </CardContent>
-            </Card>
-        );
-    }
-
     const getStatusConfig = (status: string) => {
         switch (status) {
-            case 'COMPLETED': return { label: 'Terminée', className: 'bg-green-50 text-green-700 border-green-200' };
-            case 'FAILED': return { label: 'Échouée', className: 'bg-red-50 text-red-700 border-red-200' };
+            case 'COMPLETED': return { label: 'Termin\u00e9e', className: 'bg-green-50 text-green-700 border-green-200' };
+            case 'FAILED': return { label: '\u00c9chou\u00e9e', className: 'bg-red-50 text-red-700 border-red-200' };
             case 'SENDING': return { label: 'En cours', className: 'bg-blue-50 text-blue-700 border-blue-200' };
-            case 'SCHEDULED': return { label: 'Planifiée', className: 'bg-amber-50 text-amber-700 border-amber-200' };
+            case 'SCHEDULED': return { label: 'Planifi\u00e9e', className: 'bg-amber-50 text-amber-700 border-amber-200' };
             case 'DRAFT': return { label: 'Brouillon', className: 'bg-gray-50 text-gray-600 border-gray-200' };
-            case 'CANCELLED': return { label: 'Annulée', className: 'bg-gray-50 text-gray-500 border-gray-200' };
+            case 'CANCELLED': return { label: 'Annul\u00e9e', className: 'bg-gray-50 text-gray-500 border-gray-200' };
             default: return { label: status, className: 'bg-gray-50 text-gray-600 border-gray-200' };
         }
     };
+
+    // Contextual empty state
+    const getEmptyState = () => {
+        if (statusFilter === "ALL" && searchTerm) {
+            return {
+                title: `Aucun r\u00e9sultat pour \u00ab ${searchTerm} \u00bb`,
+                description: "Essayez de modifier votre recherche.",
+                showCta: false,
+            };
+        }
+        if (statusFilter === "ALL") {
+            return {
+                title: "Aucune campagne",
+                description: "Cr\u00e9ez votre premi\u00e8re campagne de diffusion WhatsApp pour toucher vos clients.",
+                showCta: true,
+            };
+        }
+        const messages: Record<string, { title: string; description: string }> = {
+            DRAFT: { title: "Aucun brouillon", description: "Vos campagnes en pr\u00e9paration appara\u00eetront ici." },
+            SCHEDULED: { title: "Aucune campagne planifi\u00e9e", description: "Les campagnes programm\u00e9es appara\u00eetront ici." },
+            SENDING: { title: "Aucun envoi en cours", description: "Les campagnes en cours d'envoi appara\u00eetront ici." },
+            COMPLETED: { title: "Aucune campagne termin\u00e9e", description: "Les campagnes termin\u00e9es appara\u00eetront ici." },
+            FAILED: { title: "Aucune campagne \u00e9chou\u00e9e", description: "Les campagnes \u00e9chou\u00e9es appara\u00eetront ici." },
+            CANCELLED: { title: "Aucune campagne annul\u00e9e", description: "Les campagnes annul\u00e9es appara\u00eetront ici." },
+        };
+        return {
+            ...(messages[statusFilter] || { title: "Aucune campagne", description: "" }),
+            showCta: false,
+        };
+    };
+
+    const allPageSelected = paginatedBroadcasts.length > 0 && paginatedBroadcasts.every(b => selectedRows.has(b._id));
 
     return (
         <div className="space-y-5">
@@ -212,9 +381,9 @@ export const BroadcastList: React.FC = () => {
             <AlertDialog open={!!broadcastToDelete} onOpenChange={(open) => !open && setBroadcastToDelete(null)}>
                 <AlertDialogContent className="bg-white">
                     <AlertDialogHeader>
-                        <AlertDialogTitle className="text-gray-900">Êtes-vous sûr ?</AlertDialogTitle>
+                        <AlertDialogTitle className="text-gray-900">\u00cates-vous s\u00fbr ?</AlertDialogTitle>
                         <AlertDialogDescription className="text-gray-500">
-                            Cette action est irréversible. Cela supprimera définitivement la campagne et ses données associées.
+                            Cette action est irr\u00e9versible. Cela supprimera d\u00e9finitivement la campagne et ses donn\u00e9es associ\u00e9es.
                         </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>
@@ -231,7 +400,7 @@ export const BroadcastList: React.FC = () => {
 
             {/* Summary Stats */}
             <div className="grid gap-4 grid-cols-2 lg:grid-cols-4">
-                {summaryStats.map((stat, index) => {
+                {summaryStats.map((stat) => {
                     const Icon = stat.icon;
                     return (
                         <Card key={stat.title} className="bg-white border-gray-100 shadow-sm hover:shadow-md transition-shadow">
@@ -249,6 +418,36 @@ export const BroadcastList: React.FC = () => {
                 })}
             </div>
 
+            {/* Status Filter Tabs */}
+            <div className="flex items-center gap-1.5 flex-wrap">
+                {STATUS_FILTERS.map((filter) => {
+                    const count = statusCounts[filter.value] ?? 0;
+                    const isActive = statusFilter === filter.value;
+                    return (
+                        <button
+                            key={filter.value}
+                            onClick={() => handleStatusFilterChange(filter.value)}
+                            className={cn(
+                                "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium border transition-colors cursor-pointer",
+                                isActive
+                                    ? "bg-green-50 text-green-700 border-green-200"
+                                    : "text-gray-500 hover:text-gray-700 border-transparent hover:border-gray-200"
+                            )}
+                        >
+                            {filter.label}
+                            <span className={cn(
+                                "inline-flex items-center justify-center min-w-[18px] h-[18px] rounded-full px-1 text-[10px] font-semibold",
+                                isActive
+                                    ? "bg-green-100 text-green-700"
+                                    : "bg-gray-100 text-gray-500"
+                            )}>
+                                {count}
+                            </span>
+                        </button>
+                    );
+                })}
+            </div>
+
             {/* Toolbar */}
             <Card className="bg-white border-gray-100 shadow-sm">
                 <CardContent className="p-4">
@@ -257,11 +456,47 @@ export const BroadcastList: React.FC = () => {
                             <SearchInput
                                 placeholder="Rechercher une campagne..."
                                 value={searchTerm}
-                                onChange={(e) => setSearchTerm(e.target.value)}
+                                onChange={(e) => handleSearchChange(e.target.value)}
                                 className="w-full max-w-[350px]"
                             />
+
+                            {/* Sort Dropdown */}
+                            <DropdownMenu>
+                                <DropdownMenuTrigger asChild>
+                                    <Button variant="outline" size="sm" className="h-8 gap-1.5 text-xs rounded-full cursor-pointer">
+                                        <ArrowUpDown className="h-3.5 w-3.5" />
+                                        <span className="hidden sm:inline">{SORT_OPTIONS.find(o => o.value === sortBy)?.label}</span>
+                                    </Button>
+                                </DropdownMenuTrigger>
+                                <DropdownMenuContent align="start" className="w-40">
+                                    <DropdownMenuLabel className="text-[11px] text-gray-400 font-medium">Trier par</DropdownMenuLabel>
+                                    {SORT_OPTIONS.map((option) => (
+                                        <DropdownMenuItem
+                                            key={option.value}
+                                            onClick={() => handleSortChange(option.value)}
+                                            className={cn("cursor-pointer text-sm", sortBy === option.value && "font-semibold text-green-700")}
+                                        >
+                                            {option.label}
+                                        </DropdownMenuItem>
+                                    ))}
+                                </DropdownMenuContent>
+                            </DropdownMenu>
+
+                            {/* Bulk Actions */}
                             {selectedRows.size > 0 && (
                                 <div className="flex items-center gap-2 ml-2">
+                                    <Button variant="outline" size="sm" onClick={handleBatchDuplicate} className="h-8 gap-1.5 text-xs rounded-full cursor-pointer">
+                                        <Copy className="h-3.5 w-3.5" />
+                                        Dupliquer ({selectedRows.size})
+                                    </Button>
+                                    <Button variant="outline" size="sm" onClick={handleExportCsv} className="h-8 gap-1.5 text-xs rounded-full cursor-pointer">
+                                        <Download className="h-3.5 w-3.5" />
+                                        Exporter CSV
+                                    </Button>
+                                    <Button variant="outline" size="sm" onClick={handleBatchArchive} className="h-8 gap-1.5 text-xs rounded-full cursor-pointer">
+                                        <Archive className="h-3.5 w-3.5" />
+                                        Archiver ({selectedRows.size})
+                                    </Button>
                                     <Button variant="destructive" size="sm" onClick={handleBatchDelete} className="h-8 gap-1.5 text-xs rounded-full cursor-pointer">
                                         <Trash2 className="h-3.5 w-3.5" />
                                         Supprimer ({selectedRows.size})
@@ -291,27 +526,57 @@ export const BroadcastList: React.FC = () => {
                                 <TableRow className="bg-gray-50/50 hover:bg-gray-50/50">
                                     <TableHead className="w-[44px]">
                                         <Checkbox
-                                            checked={broadcasts.length > 0 && selectedRows.size === broadcasts.length}
+                                            checked={allPageSelected}
                                             onCheckedChange={toggleAll}
                                         />
                                     </TableHead>
                                     <TableHead className="text-[11px] font-semibold text-gray-500 uppercase tracking-wider">Campagne</TableHead>
                                     <TableHead className="text-[11px] font-semibold text-gray-500 uppercase tracking-wider">Statut</TableHead>
-                                    <TableHead className="text-[11px] font-semibold text-gray-500 uppercase tracking-wider hidden md:table-cell">Envoyés</TableHead>
+                                    <TableHead className="text-[11px] font-semibold text-gray-500 uppercase tracking-wider hidden md:table-cell">Canal</TableHead>
+                                    <TableHead className="text-[11px] font-semibold text-gray-500 uppercase tracking-wider hidden md:table-cell">Envoy&eacute;s</TableHead>
                                     <TableHead className="text-[11px] font-semibold text-gray-500 uppercase tracking-wider hidden lg:table-cell">Taux d&apos;ouverture</TableHead>
                                     <TableHead className="text-[11px] font-semibold text-gray-500 uppercase tracking-wider text-right">Date</TableHead>
                                     <TableHead className="w-[44px]"></TableHead>
                                 </TableRow>
                             </TableHeader>
                             <TableBody>
-                                {broadcasts.length === 0 && searchTerm ? (
+                                {sortedBroadcasts.length === 0 ? (
                                     <TableRow>
-                                        <TableCell colSpan={7} className="h-32 text-center text-sm text-gray-400">
-                                            Aucun résultat pour &quot;{searchTerm}&quot;
+                                        <TableCell colSpan={8} className="h-48">
+                                            {(() => {
+                                                const emptyState = getEmptyState();
+                                                return (
+                                                    <Empty>
+                                                        <EmptyMedia variant="icon">
+                                                            <div className={cn("h-14 w-14 rounded-full bg-gradient-to-br flex items-center justify-center shadow-lg shadow-green-900/20", STAT_GRADIENTS[0])}>
+                                                                <RadioTower className="h-7 w-7 text-white" />
+                                                            </div>
+                                                        </EmptyMedia>
+                                                        <EmptyHeader>
+                                                            <EmptyTitle className="text-gray-900">{emptyState.title}</EmptyTitle>
+                                                            <EmptyDescription className="text-gray-500">
+                                                                {emptyState.description}
+                                                            </EmptyDescription>
+                                                        </EmptyHeader>
+                                                        {emptyState.showCta && (
+                                                            <div className="mt-4">
+                                                                <Button
+                                                                    size="sm"
+                                                                    onClick={() => router.push('/dashboard/campagnes/new')}
+                                                                    className="h-8 gap-1.5 text-xs rounded-full cursor-pointer"
+                                                                >
+                                                                    <Plus className="h-3.5 w-3.5" />
+                                                                    Nouvelle Campagne
+                                                                </Button>
+                                                            </div>
+                                                        )}
+                                                    </Empty>
+                                                );
+                                            })()}
                                         </TableCell>
                                     </TableRow>
                                 ) : (
-                                    broadcasts.map((broadcast) => {
+                                    paginatedBroadcasts.map((broadcast) => {
                                         const openRate = broadcast.deliveredCount > 0 ? Math.round((broadcast.readCount / broadcast.deliveredCount) * 100) : 0;
                                         const isSelected = selectedRows.has(broadcast._id);
                                         const statusConfig = getStatusConfig(broadcast.status);
@@ -347,10 +612,15 @@ export const BroadcastList: React.FC = () => {
                                                     </span>
                                                 </TableCell>
                                                 <TableCell className="hidden md:table-cell">
+                                                    <span className="text-sm text-gray-600">
+                                                        {broadcast.channelName || "Par d\u00e9faut"}
+                                                    </span>
+                                                </TableCell>
+                                                <TableCell className="hidden md:table-cell">
                                                     <div className="flex flex-col">
                                                         <span className="text-sm font-medium text-gray-900">{broadcast.sentCount}</span>
                                                         {broadcast.failedCount > 0 && (
-                                                            <span className="text-[11px] text-red-500">{broadcast.failedCount} échecs</span>
+                                                            <span className="text-[11px] text-red-500">{broadcast.failedCount} \u00e9checs</span>
                                                         )}
                                                     </div>
                                                 </TableCell>
@@ -376,11 +646,19 @@ export const BroadcastList: React.FC = () => {
                                                         <DropdownMenuContent align="end" className="w-40">
                                                             <DropdownMenuLabel className="text-[11px] text-gray-400 font-medium">Actions</DropdownMenuLabel>
                                                             <DropdownMenuItem onClick={() => router.push(`/dashboard/campagnes/${broadcast._id}`)} className="cursor-pointer text-sm">
-                                                                <ExternalLink className="mr-2 h-3.5 w-3.5" /> Détails
+                                                                <ExternalLink className="mr-2 h-3.5 w-3.5" /> D\u00e9tails
                                                             </DropdownMenuItem>
                                                             <DropdownMenuItem onClick={() => handleDuplicate(broadcast._id)} className="cursor-pointer text-sm">
                                                                 <Copy className="mr-2 h-3.5 w-3.5" /> Dupliquer
                                                             </DropdownMenuItem>
+                                                            {(broadcast.status === "DRAFT" || broadcast.status === "COMPLETED") && (
+                                                                <DropdownMenuItem
+                                                                    onClick={() => archiveBroadcast({ id: broadcast._id }).then(() => toast.success("Campagne archiv\u00e9e")).catch(() => toast.error("Erreur lors de l'archivage"))}
+                                                                    className="cursor-pointer text-sm"
+                                                                >
+                                                                    <Archive className="mr-2 h-3.5 w-3.5" /> Archiver
+                                                                </DropdownMenuItem>
+                                                            )}
                                                             <DropdownMenuSeparator />
                                                             <DropdownMenuItem onClick={() => setBroadcastToDelete(broadcast._id)} className="text-red-600 focus:text-red-600 cursor-pointer text-sm">
                                                                 <Trash2 className="mr-2 h-3.5 w-3.5" /> Supprimer
@@ -395,6 +673,20 @@ export const BroadcastList: React.FC = () => {
                             </TableBody>
                         </Table>
                     </div>
+
+                    {/* Pagination */}
+                    {totalItems > 0 && (
+                        <div className="mt-4 flex items-center justify-between">
+                            <p className="text-xs text-gray-500">
+                                Affichage {startIndex + 1}-{endIndex} sur {totalItems} campagnes
+                            </p>
+                            <Pagination
+                                currentPage={safePage}
+                                totalPages={totalPages}
+                                onPageChange={setCurrentPage}
+                            />
+                        </div>
+                    )}
                 </CardContent>
             </Card>
         </div>

--- a/convex/_generated/dataModel.d.ts
+++ b/convex/_generated/dataModel.d.ts
@@ -38,7 +38,7 @@ export type Doc<TableName extends TableNames> = DocumentByName<
  * Convex documents are uniquely identified by their `Id`, which is accessible
  * on the `_id` field. To learn more, see [Document IDs](https://docs.convex.dev/using/document-ids).
  *
- * Documents can be loaded using `db.get(tableName, id)` in query and mutation functions.
+ * Documents can be loaded using `db.get(id)` in query and mutation functions.
  *
  * IDs are just strings at runtime, but this type can be used to distinguish them from other
  * strings when type checking.

--- a/convex/broadcasts.test.ts
+++ b/convex/broadcasts.test.ts
@@ -1,0 +1,562 @@
+import { convexTest } from "convex-test";
+import { describe, it, expect, beforeEach } from "vitest";
+import { api } from "./_generated/api";
+import schema from "./schema";
+import { modules } from "./test.modules";
+
+describe("Broadcasts", () => {
+    let t: any;
+    let userId: string;
+    let orgId: string;
+    let templateId: string;
+    let tagId1: string;
+    let tagId2: string;
+    let contactIds: string[];
+
+    beforeEach(async () => {
+        t = convexTest(schema, modules);
+
+        // Create owner user
+        userId = await t.run(async (ctx: any) => {
+            return await ctx.db.insert("users", { email: "owner@test.com", name: "Owner" });
+        });
+
+        // Create organization
+        orgId = await t.run(async (ctx: any) => {
+            return await ctx.db.insert("organizations", {
+                name: "Test Org",
+                ownerId: userId,
+                plan: "BUSINESS",
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+            });
+        });
+
+        // Create membership and userSession
+        await t.run(async (ctx: any) => {
+            await ctx.db.insert("memberships", {
+                userId,
+                organizationId: orgId,
+                role: "OWNER",
+                status: "ONLINE",
+                maxConversations: 10,
+                activeConversations: 0,
+                lastSeenAt: Date.now(),
+                joinedAt: Date.now(),
+            });
+            await ctx.db.insert("userSessions", {
+                userId,
+                currentOrganizationId: orgId,
+                lastActivityAt: Date.now(),
+            });
+        });
+
+        // Create tags
+        const tags = await t.run(async (ctx: any) => {
+            const t1 = await ctx.db.insert("tags", {
+                organizationId: orgId,
+                name: "VIP",
+                createdAt: Date.now(),
+            });
+            const t2 = await ctx.db.insert("tags", {
+                organizationId: orgId,
+                name: "Prospect",
+                createdAt: Date.now(),
+            });
+            return { tagId1: t1, tagId2: t2 };
+        });
+        tagId1 = tags.tagId1;
+        tagId2 = tags.tagId2;
+
+        // Create template with all required fields
+        templateId = await t.run(async (ctx: any) => {
+            return await ctx.db.insert("templates", {
+                organizationId: orgId,
+                name: "Welcome Template",
+                slug: "welcome",
+                type: "MARKETING",
+                category: "MARKETING",
+                language: "fr",
+                status: "APPROVED",
+                body: "Hello {{1}}",
+                sentCount: 0,
+                deliveredCount: 0,
+                readCount: 0,
+                repliedCount: 0,
+                clickedCount: 0,
+                convertedCount: 0,
+                failedCount: 0,
+                blockedCount: 0,
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+            });
+        });
+
+        // Create 5 contacts
+        contactIds = await t.run(async (ctx: any) => {
+            const c1 = await ctx.db.insert("contacts", {
+                organizationId: orgId,
+                phone: "+221701234567",
+                name: "Mamadou",
+                searchName: "mamadou +221701234567",
+                tags: [tagId1],
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+            });
+            const c2 = await ctx.db.insert("contacts", {
+                organizationId: orgId,
+                phone: "+221709876543",
+                name: "Fatou",
+                searchName: "fatou +221709876543",
+                tags: [tagId1, tagId2],
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+            });
+            const c3 = await ctx.db.insert("contacts", {
+                organizationId: orgId,
+                phone: "+33612345678",
+                name: "Pierre",
+                searchName: "pierre +33612345678",
+                tags: [tagId2],
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+            });
+            const c4 = await ctx.db.insert("contacts", {
+                organizationId: orgId,
+                phone: "+33698765432",
+                name: "Marie",
+                searchName: "marie +33698765432",
+                tags: [],
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+            });
+            const c5 = await ctx.db.insert("contacts", {
+                organizationId: orgId,
+                phone: "+1234567890",
+                name: "John",
+                searchName: "john +1234567890",
+                tags: [tagId1],
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+            });
+            return [c1, c2, c3, c4, c5];
+        });
+    });
+
+    // ============================================
+    // list
+    // ============================================
+    describe("list", () => {
+        it("should return broadcasts for organization", async () => {
+            await t.withIdentity({ subject: userId }).mutation(api.broadcasts.create, {
+                name: "Campaign Alpha",
+                templateId,
+                audienceConfig: { type: "ALL" as const },
+            });
+
+            const result = await t.withIdentity({ subject: userId }).query(api.broadcasts.list, {});
+
+            expect(result).toHaveLength(1);
+            expect(result[0].name).toBe("Campaign Alpha");
+            expect(result[0].templateName).toBe("Welcome Template");
+        });
+
+        it("should filter by search term", async () => {
+            await t.withIdentity({ subject: userId }).mutation(api.broadcasts.create, {
+                name: "Campaign Alpha",
+                templateId,
+                audienceConfig: { type: "ALL" as const },
+            });
+            await t.withIdentity({ subject: userId }).mutation(api.broadcasts.create, {
+                name: "Campaign Beta",
+                templateId,
+                audienceConfig: { type: "ALL" as const },
+            });
+
+            const result = await t.withIdentity({ subject: userId }).query(api.broadcasts.list, {
+                search: "Alpha",
+            });
+
+            expect(result).toHaveLength(1);
+            expect(result[0].name).toBe("Campaign Alpha");
+        });
+
+        it("should return enriched channel name", async () => {
+            // Create WABA first (required by whatsappChannels)
+            const wabaId = await t.run(async (ctx: any) => {
+                return await ctx.db.insert("wabas", {
+                    organizationId: orgId,
+                    metaBusinessAccountId: "meta-123",
+                    accessTokenRef: "token-ref",
+                    label: "Test WABA",
+                    createdBy: userId,
+                    createdAt: Date.now(),
+                    updatedAt: Date.now(),
+                });
+            });
+
+            const channelId = await t.run(async (ctx: any) => {
+                return await ctx.db.insert("whatsappChannels", {
+                    organizationId: orgId,
+                    wabaId,
+                    label: "Jokko Support",
+                    phoneNumberId: "phone-123",
+                    displayPhoneNumber: "+221771234567",
+                    webhookVerifyTokenRef: "verify-ref",
+                    isOrgDefault: true,
+                    status: "active" as const,
+                    createdBy: userId,
+                    createdAt: Date.now(),
+                    updatedAt: Date.now(),
+                });
+            });
+
+            await t.withIdentity({ subject: userId }).mutation(api.broadcasts.create, {
+                name: "Channel Campaign",
+                templateId,
+                audienceConfig: { type: "ALL" as const },
+                whatsappChannelId: channelId,
+            });
+
+            const result = await t.withIdentity({ subject: userId }).query(api.broadcasts.list, {});
+
+            expect(result).toHaveLength(1);
+            expect(result[0].channelName).toBe("Jokko Support");
+        });
+    });
+
+    // ============================================
+    // get
+    // ============================================
+    describe("get", () => {
+        it("should return broadcast with template and totalAudience", async () => {
+            const broadcastId = await t.withIdentity({ subject: userId }).mutation(api.broadcasts.create, {
+                name: "Full Audience",
+                templateId,
+                audienceConfig: { type: "ALL" as const },
+            });
+
+            const result = await t.withIdentity({ subject: userId }).query(api.broadcasts.get, {
+                id: broadcastId,
+            });
+
+            expect(result).not.toBeNull();
+            expect(result!.name).toBe("Full Audience");
+            expect(result!.template).not.toBeNull();
+            expect(result!.template!.name).toBe("Welcome Template");
+            expect(result!.totalAudience).toBe(5);
+        });
+
+        it("should return null for non-existent broadcast", async () => {
+            // Create a broadcast then delete it to get a valid-shaped but non-existent ID
+            const broadcastId = await t.withIdentity({ subject: userId }).mutation(api.broadcasts.create, {
+                name: "Temp",
+                templateId,
+                audienceConfig: { type: "ALL" as const },
+            });
+            await t.withIdentity({ subject: userId }).mutation(api.broadcasts.deleteBroadcast, {
+                id: broadcastId,
+            });
+
+            const result = await t.withIdentity({ subject: userId }).query(api.broadcasts.get, {
+                id: broadcastId,
+            });
+
+            expect(result).toBeNull();
+        });
+    });
+
+    // ============================================
+    // create
+    // ============================================
+    describe("create", () => {
+        it("should create a draft broadcast", async () => {
+            const broadcastId = await t.withIdentity({ subject: userId }).mutation(api.broadcasts.create, {
+                name: "Draft Campaign",
+                templateId,
+                audienceConfig: { type: "ALL" as const },
+            });
+
+            const broadcast = await t.run(async (ctx: any) => ctx.db.get(broadcastId));
+
+            expect(broadcast).not.toBeNull();
+            expect(broadcast.name).toBe("Draft Campaign");
+            expect(broadcast.status).toBe("DRAFT");
+            expect(broadcast.sentCount).toBe(0);
+            expect(broadcast.deliveredCount).toBe(0);
+            expect(broadcast.readCount).toBe(0);
+            expect(broadcast.repliedCount).toBe(0);
+            expect(broadcast.failedCount).toBe(0);
+        });
+
+        it("should create scheduled broadcast", async () => {
+            const scheduledAt = Date.now() + 86400000; // Tomorrow
+            const broadcastId = await t.withIdentity({ subject: userId }).mutation(api.broadcasts.create, {
+                name: "Scheduled Campaign",
+                templateId,
+                scheduledAt,
+                audienceConfig: { type: "ALL" as const },
+            });
+
+            const broadcast = await t.run(async (ctx: any) => ctx.db.get(broadcastId));
+
+            expect(broadcast.status).toBe("SCHEDULED");
+            expect(broadcast.scheduledAt).toBe(scheduledAt);
+        });
+
+        it("should throw for non-admin user", async () => {
+            const agentId = await t.run(async (ctx: any) => {
+                const aId = await ctx.db.insert("users", { email: "agent@test.com", name: "Agent" });
+                await ctx.db.insert("memberships", {
+                    userId: aId,
+                    organizationId: orgId,
+                    role: "AGENT",
+                    status: "ONLINE",
+                    maxConversations: 5,
+                    activeConversations: 0,
+                    lastSeenAt: Date.now(),
+                    joinedAt: Date.now(),
+                });
+                await ctx.db.insert("userSessions", {
+                    userId: aId,
+                    currentOrganizationId: orgId,
+                    lastActivityAt: Date.now(),
+                });
+                return aId;
+            });
+
+            await expect(
+                t.withIdentity({ subject: agentId }).mutation(api.broadcasts.create, {
+                    name: "Unauthorized Campaign",
+                    templateId,
+                    audienceConfig: { type: "ALL" as const },
+                })
+            ).rejects.toThrow("Permission refusée");
+        });
+    });
+
+    // ============================================
+    // estimateAudience
+    // ============================================
+    describe("estimateAudience", () => {
+        it("should count ALL contacts", async () => {
+            const result = await t.withIdentity({ subject: userId }).query(api.broadcasts.estimateAudience, {
+                audienceConfig: { type: "ALL" as const },
+            });
+
+            expect(result.count).toBe(5);
+        });
+
+        it("should count by TAGS", async () => {
+            const result = await t.withIdentity({ subject: userId }).query(api.broadcasts.estimateAudience, {
+                audienceConfig: { type: "TAGS" as const, tags: [tagId1] },
+            });
+
+            // Mamadou (tagId1), Fatou (tagId1, tagId2), John (tagId1)
+            expect(result.count).toBe(3);
+        });
+
+        it("should count by COUNTRIES", async () => {
+            const result = await t.withIdentity({ subject: userId }).query(api.broadcasts.estimateAudience, {
+                audienceConfig: { type: "COUNTRIES" as const, countries: ["+221"] },
+            });
+
+            // Mamadou (+221...), Fatou (+221...)
+            expect(result.count).toBe(2);
+        });
+
+        it("should return 0 for empty tag filter", async () => {
+            // Create a non-existent tag ID by inserting and deleting
+            const fakeTagId = await t.run(async (ctx: any) => {
+                const id = await ctx.db.insert("tags", {
+                    organizationId: orgId,
+                    name: "Temp",
+                    createdAt: Date.now(),
+                });
+                await ctx.db.delete(id);
+                return id;
+            });
+
+            const result = await t.withIdentity({ subject: userId }).query(api.broadcasts.estimateAudience, {
+                audienceConfig: { type: "TAGS" as const, tags: [fakeTagId] },
+            });
+
+            expect(result.count).toBe(0);
+        });
+    });
+
+    // ============================================
+    // duplicate
+    // ============================================
+    describe("duplicate", () => {
+        it("should duplicate broadcast as draft with reset stats", async () => {
+            const originalId = await t.withIdentity({ subject: userId }).mutation(api.broadcasts.create, {
+                name: "Original Campaign",
+                templateId,
+                audienceConfig: { type: "TAGS" as const, tags: [tagId1] },
+            });
+
+            // Manually patch some stats to simulate a sent broadcast
+            await t.run(async (ctx: any) => {
+                await ctx.db.patch(originalId, {
+                    status: "COMPLETED",
+                    sentCount: 100,
+                    deliveredCount: 95,
+                    readCount: 50,
+                    repliedCount: 10,
+                    failedCount: 5,
+                });
+            });
+
+            const duplicateId = await t.withIdentity({ subject: userId }).mutation(api.broadcasts.duplicate, {
+                id: originalId,
+            });
+
+            const duplicate = await t.run(async (ctx: any) => ctx.db.get(duplicateId));
+
+            expect(duplicate.name).toBe("Original Campaign (Copie)");
+            expect(duplicate.status).toBe("DRAFT");
+            expect(duplicate.sentCount).toBe(0);
+            expect(duplicate.deliveredCount).toBe(0);
+            expect(duplicate.readCount).toBe(0);
+            expect(duplicate.repliedCount).toBe(0);
+            expect(duplicate.failedCount).toBe(0);
+            expect(duplicate.templateId).toBe(templateId);
+            expect(duplicate.audienceConfig.type).toBe("TAGS");
+        });
+    });
+
+    // ============================================
+    // deleteBroadcast
+    // ============================================
+    describe("deleteBroadcast", () => {
+        it("should delete broadcast", async () => {
+            const broadcastId = await t.withIdentity({ subject: userId }).mutation(api.broadcasts.create, {
+                name: "To Delete",
+                templateId,
+                audienceConfig: { type: "ALL" as const },
+            });
+
+            await t.withIdentity({ subject: userId }).mutation(api.broadcasts.deleteBroadcast, {
+                id: broadcastId,
+            });
+
+            const broadcast = await t.run(async (ctx: any) => ctx.db.get(broadcastId));
+            expect(broadcast).toBeNull();
+        });
+
+        it("should throw for non-admin", async () => {
+            const broadcastId = await t.withIdentity({ subject: userId }).mutation(api.broadcasts.create, {
+                name: "Protected",
+                templateId,
+                audienceConfig: { type: "ALL" as const },
+            });
+
+            const agentId = await t.run(async (ctx: any) => {
+                const aId = await ctx.db.insert("users", { email: "agent@test.com", name: "Agent" });
+                await ctx.db.insert("memberships", {
+                    userId: aId,
+                    organizationId: orgId,
+                    role: "AGENT",
+                    status: "ONLINE",
+                    maxConversations: 5,
+                    activeConversations: 0,
+                    lastSeenAt: Date.now(),
+                    joinedAt: Date.now(),
+                });
+                await ctx.db.insert("userSessions", {
+                    userId: aId,
+                    currentOrganizationId: orgId,
+                    lastActivityAt: Date.now(),
+                });
+                return aId;
+            });
+
+            await expect(
+                t.withIdentity({ subject: agentId }).mutation(api.broadcasts.deleteBroadcast, {
+                    id: broadcastId,
+                })
+            ).rejects.toThrow();
+        });
+    });
+
+    // ============================================
+    // archiveBroadcast
+    // ============================================
+    describe("archiveBroadcast", () => {
+        it("should archive broadcast", async () => {
+            const broadcastId = await t.withIdentity({ subject: userId }).mutation(api.broadcasts.create, {
+                name: "To Archive",
+                templateId,
+                audienceConfig: { type: "ALL" as const },
+            });
+
+            await t.withIdentity({ subject: userId }).mutation(api.broadcasts.archiveBroadcast, {
+                id: broadcastId,
+            });
+
+            const broadcast = await t.run(async (ctx: any) => ctx.db.get(broadcastId));
+            expect(broadcast.status).toBe("CANCELLED");
+        });
+    });
+
+    // ============================================
+    // getActivity
+    // ============================================
+    describe("getActivity", () => {
+        it("should return creation event", async () => {
+            const broadcastId = await t.withIdentity({ subject: userId }).mutation(api.broadcasts.create, {
+                name: "Activity Test",
+                templateId,
+                audienceConfig: { type: "ALL" as const },
+            });
+
+            const result = await t.withIdentity({ subject: userId }).query(api.broadcasts.getActivity, {
+                broadcastId,
+            });
+
+            expect(result.activities.length).toBeGreaterThanOrEqual(1);
+            const createdEvent = result.activities.find((a: any) => a.type === "created");
+            expect(createdEvent).toBeDefined();
+        });
+    });
+
+    // ============================================
+    // exportBroadcasts
+    // ============================================
+    describe("exportBroadcasts", () => {
+        it("should export broadcasts as flat objects", async () => {
+            await t.withIdentity({ subject: userId }).mutation(api.broadcasts.create, {
+                name: "Export Campaign 1",
+                templateId,
+                audienceConfig: { type: "ALL" as const },
+            });
+            await t.withIdentity({ subject: userId }).mutation(api.broadcasts.create, {
+                name: "Export Campaign 2",
+                templateId,
+                audienceConfig: { type: "TAGS" as const, tags: [tagId1] },
+            });
+
+            const result = await t.withIdentity({ subject: userId }).query(api.broadcasts.exportBroadcasts, {});
+
+            expect(result).toHaveLength(2);
+
+            // Verify flat object shape
+            for (const item of result) {
+                expect(item).toHaveProperty("name");
+                expect(item).toHaveProperty("templateName");
+                expect(item).toHaveProperty("status");
+                expect(item).toHaveProperty("sentCount");
+                expect(item).toHaveProperty("deliveredCount");
+                expect(item).toHaveProperty("readCount");
+                expect(item).toHaveProperty("repliedCount");
+                expect(item).toHaveProperty("failedCount");
+                expect(item).toHaveProperty("createdAt");
+                expect(item).toHaveProperty("completedAt");
+                expect(item.templateName).toBe("Welcome Template");
+                expect(item.status).toBe("DRAFT");
+                expect(item.sentCount).toBe(0);
+            }
+        });
+    });
+});

--- a/convex/broadcasts.ts
+++ b/convex/broadcasts.ts
@@ -42,9 +42,15 @@ export const list = query({
         const enrichedBroadcasts = await Promise.all(
             broadcasts.map(async (b) => {
                 const template = await ctx.db.get(b.templateId);
+                let channelName: string | null = null;
+                if (b.whatsappChannelId) {
+                    const channel = await ctx.db.get(b.whatsappChannelId);
+                    channelName = channel?.label ?? null;
+                }
                 return {
                     ...b,
-                    templateName: template?.name || "Unknown Template"
+                    templateName: template?.name || "Unknown Template",
+                    channelName,
                 };
             })
         );
@@ -83,9 +89,36 @@ export const get = query({
 
         const template = await ctx.db.get(broadcast.templateId);
 
+        // Channel name
+        let channelName: string | null = null;
+        if (broadcast.whatsappChannelId) {
+            const channel = await ctx.db.get(broadcast.whatsappChannelId);
+            channelName = channel?.label ?? null;
+        }
+
+        // Total audience count (same logic as estimateAudience)
+        const contacts = await ctx.db
+            .query("contacts")
+            .withIndex("by_organization", (q) => q.eq("organizationId", broadcast.organizationId))
+            .collect();
+
+        let totalAudience = contacts.length;
+        const config = broadcast.audienceConfig;
+        if (config.type === "TAGS" && config.tags && config.tags.length > 0) {
+            totalAudience = contacts.filter((c) =>
+                c.tags && c.tags.some((t) => config.tags!.includes(t))
+            ).length;
+        } else if (config.type === "COUNTRIES" && config.countries && config.countries.length > 0) {
+            totalAudience = contacts.filter((c) =>
+                config.countries!.some((prefix) => c.phone.startsWith(prefix))
+            ).length;
+        }
+
         return {
             ...broadcast,
-            template
+            template,
+            channelName,
+            totalAudience,
         };
     },
 });
@@ -140,6 +173,23 @@ export const create = mutation({
             updatedAt: Date.now(),
         });
 
+        // Log activity
+        await ctx.db.insert("broadcastActivities", {
+            broadcastId: id,
+            type: "created",
+            message: `Campagne "${args.name}" créée`,
+            createdAt: Date.now(),
+        });
+
+        if (args.scheduledAt) {
+            await ctx.db.insert("broadcastActivities", {
+                broadcastId: id,
+                type: "scheduled",
+                message: `Campagne planifiée pour le ${new Date(args.scheduledAt).toLocaleDateString("fr-FR")}`,
+                createdAt: Date.now(),
+            });
+        }
+
         return id;
     },
 });
@@ -186,6 +236,32 @@ export const update = mutation({
         const statusChanged = args.status && args.status !== broadcast.status;
 
         await ctx.db.patch(args.id, updates);
+
+        // Log activity for status changes
+        if (statusChanged) {
+            if (args.status === 'SENDING') {
+                await ctx.db.insert("broadcastActivities", {
+                    broadcastId: args.id,
+                    type: "sending_started",
+                    message: "Envoi de la campagne démarré",
+                    createdAt: Date.now(),
+                });
+            } else if (args.status === 'SCHEDULED') {
+                await ctx.db.insert("broadcastActivities", {
+                    broadcastId: args.id,
+                    type: "scheduled",
+                    message: "Campagne planifiée",
+                    createdAt: Date.now(),
+                });
+            } else if (args.status === 'CANCELLED') {
+                await ctx.db.insert("broadcastActivities", {
+                    broadcastId: args.id,
+                    type: "cancelled",
+                    message: "Campagne annulée",
+                    createdAt: Date.now(),
+                });
+            }
+        }
 
         // TRIGGER SENDING IF STATUS -> SENDING
         if (statusChanged && args.status === 'SENDING') {
@@ -359,10 +435,29 @@ export const sendBroadcast = internalAction({
 export const markCompleted = internalMutation({
     args: { id: v.id("broadcasts") },
     handler: async (ctx, args) => {
+        const broadcast = await ctx.db.get(args.id);
         await ctx.db.patch(args.id, {
             status: "COMPLETED",
             completedAt: Date.now()
         });
+
+        // Log completion activity
+        await ctx.db.insert("broadcastActivities", {
+            broadcastId: args.id,
+            type: "completed",
+            message: `Campagne terminée — ${broadcast?.sentCount ?? 0} envoyés, ${broadcast?.failedCount ?? 0} échecs`,
+            createdAt: Date.now(),
+        });
+
+        // Log failures if any
+        if (broadcast && broadcast.failedCount > 0) {
+            await ctx.db.insert("broadcastActivities", {
+                broadcastId: args.id,
+                type: "failures",
+                message: `${broadcast.failedCount} message(s) en échec`,
+                createdAt: Date.now(),
+            });
+        }
     }
 });
 
@@ -422,6 +517,39 @@ export const deleteBroadcast = mutation({
     },
 });
 
+export const archiveBroadcast = mutation({
+    args: { id: v.id("broadcasts") },
+    handler: async (ctx, args) => {
+        const userId = await getAuthUserId(ctx);
+        if (!userId) throw new Error("Unauthorized");
+
+        const broadcast = await ctx.db.get(args.id);
+        if (!broadcast) throw new Error("Broadcast not found");
+
+        const session = await ctx.db
+            .query("userSessions")
+            .withIndex("by_user", (q) => q.eq("userId", userId))
+            .first();
+
+        if (session?.currentOrganizationId !== broadcast.organizationId) {
+            throw new Error("Unauthorized");
+        }
+
+        // Permission check: only ADMIN+ can archive broadcasts
+        const membership = await ctx.db.query("memberships")
+            .withIndex("by_user_org", q => q.eq("userId", userId).eq("organizationId", broadcast.organizationId))
+            .first();
+        if (!membership || (membership.role !== "ADMIN" && membership.role !== "OWNER")) {
+            throw new Error("Permission refusée: seuls les admins peuvent archiver des broadcasts");
+        }
+
+        await ctx.db.patch(args.id, {
+            status: "CANCELLED",
+            updatedAt: Date.now(),
+        });
+    },
+});
+
 export const duplicate = mutation({
     args: { id: v.id("broadcasts") },
     handler: async (ctx, args) => {
@@ -457,5 +585,285 @@ export const duplicate = mutation({
         });
 
         return newId;
+    },
+});
+
+// ===================================
+// AUDIENCE ESTIMATION
+// ===================================
+
+export const estimateAudience = query({
+    args: {
+        audienceConfig: v.object({
+            type: v.union(v.literal("ALL"), v.literal("TAGS"), v.literal("COUNTRIES")),
+            tags: v.optional(v.array(v.id("tags"))),
+            countries: v.optional(v.array(v.string())),
+        }),
+    },
+    handler: async (ctx, args) => {
+        const userId = await getAuthUserId(ctx);
+        if (!userId) throw new Error("Unauthorized");
+
+        const session = await ctx.db
+            .query("userSessions")
+            .withIndex("by_user", (q) => q.eq("userId", userId))
+            .first();
+
+        if (!session?.currentOrganizationId) {
+            return { count: 0 };
+        }
+
+        const organizationId = session.currentOrganizationId;
+
+        const contacts = await ctx.db
+            .query("contacts")
+            .withIndex("by_organization", (q) => q.eq("organizationId", organizationId))
+            .collect();
+
+        const config = args.audienceConfig;
+
+        if (config.type === "ALL") {
+            return { count: contacts.length };
+        }
+
+        if (config.type === "TAGS" && config.tags && config.tags.length > 0) {
+            const matched = contacts.filter((c) =>
+                c.tags && c.tags.some((t) => config.tags!.includes(t))
+            );
+            return { count: matched.length };
+        }
+
+        if (config.type === "COUNTRIES" && config.countries && config.countries.length > 0) {
+            const matched = contacts.filter((c) =>
+                config.countries!.some((prefix) => c.phone.startsWith(prefix))
+            );
+            return { count: matched.length };
+        }
+
+        return { count: contacts.length };
+    },
+});
+
+// ===================================
+// RETRY FAILED MESSAGES
+// ===================================
+
+export const retryFailed = mutation({
+    args: {
+        broadcastId: v.id("broadcasts"),
+    },
+    handler: async (ctx, args) => {
+        const userId = await getAuthUserId(ctx);
+        if (!userId) throw new Error("Unauthorized");
+
+        const session = await ctx.db
+            .query("userSessions")
+            .withIndex("by_user", (q) => q.eq("userId", userId))
+            .first();
+
+        if (!session?.currentOrganizationId) {
+            throw new Error("No organization selected");
+        }
+
+        const organizationId = session.currentOrganizationId;
+
+        // Permission check: only ADMIN+ can retry
+        const membership = await ctx.db.query("memberships")
+            .withIndex("by_user_org", (q) => q.eq("userId", userId).eq("organizationId", organizationId))
+            .first();
+        if (!membership || (membership.role !== "ADMIN" && membership.role !== "OWNER")) {
+            throw new Error("Permission refusée: seuls les admins peuvent relancer des broadcasts");
+        }
+
+        const broadcast = await ctx.db.get(args.broadcastId);
+        if (!broadcast) throw new Error("Broadcast not found");
+        if (broadcast.organizationId !== organizationId) {
+            throw new Error("Unauthorized");
+        }
+
+        // Get the template for re-sending
+        const template = await ctx.db.get(broadcast.templateId);
+        if (!template) throw new Error("Template not found");
+
+        // Find failed messages for this broadcast (no by_broadcast index, use filter)
+        const failedMessages = await ctx.db
+            .query("messages")
+            .withIndex("by_organization", (q) => q.eq("organizationId", organizationId))
+            .filter((q) =>
+                q.and(
+                    q.eq(q.field("broadcastId"), args.broadcastId),
+                    q.eq(q.field("status"), "FAILED")
+                )
+            )
+            .collect();
+
+        let retriedCount = 0;
+
+        for (const msg of failedMessages) {
+            if (!msg.contactId) continue;
+
+            const contact = await ctx.db.get(msg.contactId);
+            if (!contact) continue;
+
+            await ctx.scheduler.runAfter(0, internal.broadcasts.sendSingleToContact, {
+                broadcastId: args.broadcastId,
+                organizationId,
+                contactId: contact._id,
+                phone: contact.phone,
+                templateName: template.name,
+                languageCode: template.language,
+                components: [],
+            });
+
+            retriedCount++;
+        }
+
+        // Reset failedCount and update status
+        const updates: Record<string, unknown> = {
+            failedCount: 0,
+            updatedAt: Date.now(),
+        };
+        if (broadcast.status === "COMPLETED" || broadcast.status === "FAILED") {
+            updates.status = "SENDING";
+        }
+        await ctx.db.patch(args.broadcastId, updates);
+
+        return { retriedCount };
+    },
+});
+
+// ===================================
+// ACTIVITY TIMELINE
+// ===================================
+
+export const getActivity = query({
+    args: {
+        broadcastId: v.id("broadcasts"),
+    },
+    handler: async (ctx, args) => {
+        const userId = await getAuthUserId(ctx);
+        if (!userId) throw new Error("Unauthorized");
+
+        const session = await ctx.db
+            .query("userSessions")
+            .withIndex("by_user", (q) => q.eq("userId", userId))
+            .first();
+
+        if (!session?.currentOrganizationId) {
+            throw new Error("No organization selected");
+        }
+
+        const broadcast = await ctx.db.get(args.broadcastId);
+        if (!broadcast) throw new Error("Broadcast not found");
+        if (broadcast.organizationId !== session.currentOrganizationId) {
+            throw new Error("Unauthorized access to this broadcast");
+        }
+
+        const activities: Array<{
+            type: string;
+            timestamp: number;
+            message: string;
+        }> = [];
+
+        // Created
+        activities.push({
+            type: "created",
+            timestamp: broadcast.createdAt,
+            message: "Campagne créée",
+        });
+
+        // Scheduled
+        if (broadcast.scheduledAt) {
+            const scheduledDate = new Date(broadcast.scheduledAt).toLocaleString("fr-FR", {
+                dateStyle: "long",
+                timeStyle: "short",
+            });
+            activities.push({
+                type: "scheduled",
+                timestamp: broadcast.scheduledAt,
+                message: `Planifiée pour le ${scheduledDate}`,
+            });
+        }
+
+        // Sending started
+        if (broadcast.status === "SENDING" || broadcast.status === "COMPLETED" || broadcast.status === "FAILED") {
+            activities.push({
+                type: "sending_started",
+                timestamp: broadcast.updatedAt,
+                message: "Envoi démarré",
+            });
+        }
+
+        // Completed
+        if (broadcast.completedAt) {
+            activities.push({
+                type: "completed",
+                timestamp: broadcast.completedAt,
+                message: `Envoi terminé — ${broadcast.sentCount} messages envoyés`,
+            });
+        }
+
+        // Failures
+        if (broadcast.failedCount > 0) {
+            activities.push({
+                type: "failures",
+                timestamp: broadcast.updatedAt,
+                message: `${broadcast.failedCount} messages en échec`,
+            });
+        }
+
+        // Sort by timestamp descending
+        activities.sort((a, b) => b.timestamp - a.timestamp);
+
+        return { activities };
+    },
+});
+
+// ===================================
+// EXPORT BROADCASTS
+// ===================================
+
+export const exportBroadcasts = query({
+    args: {},
+    handler: async (ctx) => {
+        const userId = await getAuthUserId(ctx);
+        if (!userId) throw new Error("Unauthorized");
+
+        const session = await ctx.db
+            .query("userSessions")
+            .withIndex("by_user", (q) => q.eq("userId", userId))
+            .first();
+
+        if (!session?.currentOrganizationId) {
+            return [];
+        }
+
+        const organizationId = session.currentOrganizationId;
+
+        const broadcasts = await ctx.db
+            .query("broadcasts")
+            .withIndex("by_organization", (q) => q.eq("organizationId", organizationId))
+            .order("desc")
+            .collect();
+
+        const result = await Promise.all(
+            broadcasts.map(async (b) => {
+                const template = await ctx.db.get(b.templateId);
+                return {
+                    name: b.name,
+                    templateName: template?.name || "Unknown Template",
+                    status: b.status,
+                    sentCount: b.sentCount,
+                    deliveredCount: b.deliveredCount,
+                    readCount: b.readCount,
+                    repliedCount: b.repliedCount,
+                    failedCount: b.failedCount,
+                    createdAt: new Date(b.createdAt).toISOString(),
+                    completedAt: b.completedAt ? new Date(b.completedAt).toISOString() : "",
+                };
+            })
+        );
+
+        return result;
     },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -709,6 +709,22 @@ export default defineSchema({
         .index("by_status", ["status"])
         .index("by_channel", ["whatsappChannelId"]),
 
+    broadcastActivities: defineTable({
+        broadcastId: v.id("broadcasts"),
+        type: v.union(
+            v.literal("created"),
+            v.literal("scheduled"),
+            v.literal("sending_started"),
+            v.literal("completed"),
+            v.literal("failures"),
+            v.literal("cancelled"),
+            v.literal("retry")
+        ),
+        message: v.string(),
+        createdAt: v.number(),
+    })
+        .index("by_broadcast", ["broadcastId"]),
+
     shortcuts: defineTable({
         organizationId: v.id("organizations"),
         shortcut: v.string(), // Trigger command (e.g., "/intro")

--- a/e2e/campaigns.spec.ts
+++ b/e2e/campaigns.spec.ts
@@ -1,0 +1,207 @@
+import { test, expect } from '@playwright/test';
+
+const CAMPAIGNS_URL = 'http://localhost:3000/dashboard/campagnes';
+
+test.describe('Campaigns Page', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto(CAMPAIGNS_URL);
+        await page.waitForLoadState('networkidle');
+    });
+
+    test('should load the campaigns page', async ({ page }) => {
+        await expect(page.locator('body')).toBeVisible();
+    });
+
+    test('should display campaign summary stats', async ({ page }) => {
+        const statCards = page.locator('[class*="bg-gradient"]');
+        const count = await statCards.count();
+        if (count < 1) {
+            test.skip();
+            return;
+        }
+        expect(count).toBeGreaterThanOrEqual(1);
+    });
+
+    test('should display status filter tabs', async ({ page }) => {
+        const allTab = page.locator('button, [role="tab"]').filter({ hasText: /tous/i }).first();
+        const visible = await allTab.isVisible().catch(() => false);
+        if (!visible) {
+            test.skip();
+            return;
+        }
+        await expect(allTab).toBeVisible();
+
+        const brouillonTab = page.locator('button, [role="tab"]').filter({ hasText: /brouillon/i }).first();
+        const termineeTab = page.locator('button, [role="tab"]').filter({ hasText: /terminée/i }).first();
+        const brouillonVisible = await brouillonTab.isVisible().catch(() => false);
+        const termineeVisible = await termineeTab.isVisible().catch(() => false);
+        expect(brouillonVisible || termineeVisible).toBeTruthy();
+    });
+
+    test('should filter campaigns by status', async ({ page }) => {
+        const brouillonTab = page.locator('button, [role="tab"]').filter({ hasText: /brouillon/i }).first();
+        const visible = await brouillonTab.isVisible().catch(() => false);
+        if (!visible) {
+            test.skip();
+            return;
+        }
+        await brouillonTab.click();
+        await page.waitForTimeout(300);
+        await expect(page.locator('body')).toBeVisible();
+    });
+
+    test('should display sort dropdown', async ({ page }) => {
+        const sortBtn = page.locator('button, select, [role="combobox"]').filter({ hasText: /trier|récente|tri/i }).first();
+        const visible = await sortBtn.isVisible().catch(() => false);
+        if (!visible) {
+            test.skip();
+            return;
+        }
+        await expect(sortBtn).toBeVisible();
+    });
+
+    test('should display search input', async ({ page }) => {
+        const searchInput = page.getByPlaceholder(/rechercher/i);
+        const visible = await searchInput.isVisible().catch(() => false);
+        if (!visible) {
+            test.skip();
+            return;
+        }
+        await expect(searchInput).toBeVisible();
+    });
+
+    test('should filter campaigns by search', async ({ page }) => {
+        const searchInput = page.getByPlaceholder(/rechercher/i);
+        const visible = await searchInput.isVisible().catch(() => false);
+        if (!visible) {
+            test.skip();
+            return;
+        }
+        await searchInput.fill('test');
+        await page.waitForTimeout(300);
+        await expect(page.locator('body')).toBeVisible();
+    });
+
+    test('should display campaigns table', async ({ page }) => {
+        const table = page.locator('table, [role="table"]').first();
+        const visible = await table.isVisible().catch(() => false);
+        if (!visible) {
+            test.skip();
+            return;
+        }
+        await expect(table).toBeVisible();
+
+        const headers = page.locator('th, [role="columnheader"]');
+        const headerCount = await headers.count();
+        expect(headerCount).toBeGreaterThan(0);
+    });
+
+    test('should have new campaign button', async ({ page }) => {
+        const newBtn = page.getByRole('button', { name: /nouvelle campagne|nouveau|créer/i });
+        const visible = await newBtn.isVisible().catch(() => false);
+        if (!visible) {
+            test.skip();
+            return;
+        }
+        await expect(newBtn).toBeVisible();
+    });
+
+    test('should navigate to new campaign page', async ({ page }) => {
+        const newBtn = page.getByRole('button', { name: /nouvelle campagne|nouveau|créer/i });
+        const visible = await newBtn.isVisible().catch(() => false);
+        if (!visible) {
+            // Try link variant
+            const newLink = page.getByRole('link', { name: /nouvelle campagne|nouveau|créer/i });
+            const linkVisible = await newLink.isVisible().catch(() => false);
+            if (!linkVisible) {
+                test.skip();
+                return;
+            }
+            await newLink.click();
+        } else {
+            await newBtn.click();
+        }
+        await page.waitForLoadState('networkidle');
+        expect(page.url()).toContain('/campagnes/new');
+    });
+
+    test('should display audience estimation on new page', async ({ page }) => {
+        await page.goto(CAMPAIGNS_URL + '/new');
+        await page.waitForLoadState('networkidle');
+
+        const audienceText = page.locator('text=/contacts ciblés|contacts cibles/i').first();
+        const visible = await audienceText.isVisible().catch(() => false);
+        if (!visible) {
+            test.skip();
+            return;
+        }
+        await expect(audienceText).toBeVisible();
+    });
+
+    test('should display template preview on new page', async ({ page }) => {
+        await page.goto(CAMPAIGNS_URL + '/new');
+        await page.waitForLoadState('networkidle');
+
+        const previewText = page.locator('text=/aperçu|preview/i').first();
+        const visible = await previewText.isVisible().catch(() => false);
+        if (!visible) {
+            test.skip();
+            return;
+        }
+        await expect(previewText).toBeVisible();
+    });
+
+    test('should display pagination', async ({ page }) => {
+        const pagination = page.locator('nav[aria-label*="pagination"], [role="navigation"]').first();
+        const paginationText = page.locator('text=/affichage|page/i').first();
+
+        const navVisible = await pagination.isVisible().catch(() => false);
+        const textVisible = await paginationText.isVisible().catch(() => false);
+
+        if (!navVisible && !textVisible) {
+            test.skip();
+            return;
+        }
+
+        if (navVisible) {
+            await expect(pagination).toBeVisible();
+        } else {
+            await expect(paginationText).toBeVisible();
+        }
+    });
+
+    test('should have bulk action buttons when selecting', async ({ page }) => {
+        const checkboxes = page.locator('input[type="checkbox"], [role="checkbox"]');
+        const count = await checkboxes.count();
+        if (count < 1) {
+            test.skip();
+            return;
+        }
+
+        await checkboxes.first().click();
+        await page.waitForTimeout(300);
+
+        const actionBtn = page.locator('button').filter({ hasText: /dupliquer|exporter|archiver/i }).first();
+        const visible = await actionBtn.isVisible().catch(() => false);
+        if (!visible) {
+            test.skip();
+            return;
+        }
+        await expect(actionBtn).toBeVisible();
+    });
+
+    test('should load without console errors', async ({ page }) => {
+        const errors: string[] = [];
+        page.on('console', (msg) => {
+            if (msg.type() === 'error') errors.push(msg.text());
+        });
+
+        await page.goto(CAMPAIGNS_URL);
+        await page.waitForLoadState('networkidle');
+
+        const criticalErrors = errors.filter(
+            (e) => !e.includes('convex') && !e.includes('Warning') && !e.includes('hydration')
+        );
+        expect(criticalErrors).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
## Summary
- **Backend**: 5 nouvelles queries/mutations (estimateAudience, retryFailed, getActivity, archiveBroadcast, exportBroadcasts) + enrichissement list/get avec channelName et totalAudience
- **Liste campagnes**: Filtres par statut (7 onglets), tri (4 options), pagination (10/page), actions groupées enrichies (dupliquer, exporter CSV, archiver), colonne canal WhatsApp, états vides contextuels
- **Page détail**: Barre de progression temps réel, timeline d'activité, dialog de confirmation avant envoi, retry messages échoués, comparaison entre campagnes, affichage du canal
- **Page création**: Estimation d'audience en temps réel, prévisualisation du template WhatsApp
- **Tests**: 18 tests unitaires vitest + 15 tests Playwright E2E

## Test plan
- [x] `pnpm build` — OK
- [x] `pnpx convex typecheck` — OK
- [x] `npx vitest run broadcasts` — 18/18 tests passing
- [x] `pnpx convex deploy` — Deployed to production

🤖 Generated with [Claude Code](https://claude.com/claude-code)