### PR TITLE
feat(calls): WhatsApp Business Calling (inbound + outbound)

### DIFF
--- a/app/dashboard/_components/dashboard-layout-client.tsx
+++ b/app/dashboard/_components/dashboard-layout-client.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { Sidebar, DashboardHeader } from '@/components/dashboard'
 import { BrowserNotifications } from '@/components/browser-notifications'
 import { NotificationBanner } from '@/components/dashboard/notification-banner'
+import { CallNotificationProvider } from '@/components/calls/call-notification-provider'
 import { usePresence } from '@/hooks/use-presence'
 import { useCurrentOrg } from '@/hooks/use-current-org'
 import { Id } from '@/convex/_generated/dataModel'
@@ -50,6 +51,7 @@ export function DashboardLayoutClient({
             <div className="flex flex-1 flex-col overflow-hidden">
                 <NotificationBanner />
                 <BrowserNotifications />
+                <CallNotificationProvider />
                 {/* Header with mobile sidebar */}
                 <DashboardHeader
                     basePath={basePath}

--- a/app/facebook-connect/page.tsx
+++ b/app/facebook-connect/page.tsx
@@ -64,15 +64,6 @@ export default function FacebookConnectPage() {
 
         setStatus('logging-in');
 
-        // Re-init FB right before login — required by FB SDK
-        const appId = process.env.NEXT_PUBLIC_FACEBOOK_APP_ID || '';
-        window.FB.init({
-            appId,
-            cookie: true,
-            xfbml: true,
-            version: 'v22.0',
-        });
-
         window.FB.login(
             (response: any) => {
                 if (response.authResponse?.accessToken) {

--- a/components/calls/active-call-bar.tsx
+++ b/components/calls/active-call-bar.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { Phone, PhoneOff, PhoneOutgoing, Mic, MicOff, Loader2, X, AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useCallStore } from '@/lib/stores/call-store';
+import { useWebRTCCall } from '@/hooks/use-webrtc-call';
+import { useState, useEffect } from 'react';
+import { CallErrorActionButton } from './call-error-action-button';
+
+export function ActiveCallBar() {
+    const { activeCallId, callState, contactName, contactPhone, callStartedAt, callDirection, errorMessage, clearCall } = useCallStore();
+    const { hangUp, toggleMute, isMuted, remoteAudioRef } = useWebRTCCall();
+    const [elapsed, setElapsed] = useState(0);
+
+    const isActive = callState === 'connecting' || callState === 'connected' || callState === 'dialing';
+    const isOutboundPending = callState === 'requesting_permission' || callState === 'permission_granted';
+    const isError = callState === 'error';
+    const showBar = isActive || isOutboundPending || isError;
+
+    // Timer
+    useEffect(() => {
+        if (callState !== 'connected' || !callStartedAt) {
+            setElapsed(0);
+            return;
+        }
+
+        const interval = setInterval(() => {
+            setElapsed(Math.floor((Date.now() - callStartedAt) / 1000));
+        }, 1000);
+
+        return () => clearInterval(interval);
+    }, [callState, callStartedAt]);
+
+    if (!showBar) return null;
+    if (!activeCallId && !isError) return null;
+
+    const displayName = contactName || contactPhone || 'Inconnu';
+    const minutes = Math.floor(elapsed / 60);
+    const seconds = elapsed % 60;
+    const timeStr = `${minutes}:${String(seconds).padStart(2, '0')}`;
+
+    const handleHangUp = async () => {
+        if (activeCallId) {
+            await hangUp(activeCallId);
+        }
+    };
+
+    // Determine status text and bar color
+    let statusText: string;
+    let barColorClass: string;
+
+    if (callState === 'requesting_permission') {
+        statusText = 'Demande de permission envoyee...';
+        barColorClass = 'border-yellow-200 bg-yellow-50 dark:border-yellow-800 dark:bg-yellow-950/30';
+    } else if (callState === 'permission_granted') {
+        statusText = 'Permission accordee - Lancement de l\'appel...';
+        barColorClass = 'border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/30';
+    } else if (callState === 'dialing') {
+        statusText = 'Appel en cours...';
+        barColorClass = 'border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/30';
+    } else if (callState === 'connecting') {
+        statusText = 'Connexion...';
+        barColorClass = 'border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/30';
+    } else if (callState === 'error') {
+        statusText = errorMessage || 'Erreur d\'appel';
+        barColorClass = 'border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950/30';
+    } else {
+        statusText = timeStr;
+        barColorClass = 'border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/30';
+    }
+
+    return (
+        <>
+            <audio ref={remoteAudioRef} autoPlay playsInline />
+
+            <div className={`flex items-center justify-between border-b px-4 py-2 ${barColorClass}`}>
+                <div className="flex items-center gap-3">
+                    <div className={`flex h-8 w-8 items-center justify-center rounded-full ${isError ? 'bg-red-600' : 'bg-green-600'}`}>
+                        {isError ? (
+                            <AlertCircle className="h-4 w-4 text-white" />
+                        ) : callState === 'requesting_permission' ? (
+                            <Loader2 className="h-4 w-4 animate-spin text-white" />
+                        ) : callDirection === 'OUTBOUND' ? (
+                            <PhoneOutgoing className="h-4 w-4 text-white" />
+                        ) : (
+                            <Phone className="h-4 w-4 text-white" />
+                        )}
+                    </div>
+                    <div>
+                        <p className="text-sm font-medium text-zinc-900 dark:text-zinc-100">
+                            {displayName}
+                        </p>
+                        <p className="text-xs text-zinc-500">
+                            {statusText}
+                        </p>
+                    </div>
+                </div>
+
+                <div className="flex items-center gap-2">
+                    {/* Contextual fix-it button based on the error type */}
+                    {isError && <CallErrorActionButton />}
+
+                    {/* Cancel/Close for pending outbound or error */}
+                    {(isOutboundPending || isError) && (
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            className="text-zinc-500 hover:text-zinc-700"
+                            onClick={clearCall}
+                        >
+                            <X className="h-4 w-4" />
+                        </Button>
+                    )}
+
+                    {/* Mute button (only during active call) */}
+                    {isActive && (
+                        <Button
+                            variant="ghost"
+                            size="icon"
+                            className={isMuted ? 'text-red-500' : 'text-zinc-600'}
+                            onClick={toggleMute}
+                        >
+                            {isMuted ? <MicOff className="h-4 w-4" /> : <Mic className="h-4 w-4" />}
+                        </Button>
+                    )}
+
+                    {/* Hang up (during active call or dialing) */}
+                    {isActive && (
+                        <Button
+                            variant="destructive"
+                            size="sm"
+                            className="gap-1"
+                            onClick={handleHangUp}
+                        >
+                            <PhoneOff className="h-4 w-4" />
+                            Raccrocher
+                        </Button>
+                    )}
+                </div>
+            </div>
+        </>
+    );
+}

--- a/components/calls/call-button.tsx
+++ b/components/calls/call-button.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { Phone, PhoneCall, Loader2, AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { useCallStore } from '@/lib/stores/call-store';
+import { useWebRTCCall } from '@/hooks/use-webrtc-call';
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
+import { mapCallError } from './call-error-messages';
+
+interface CallButtonProps {
+    conversationId?: string;
+    contactPhone?: string;
+    contactName?: string;
+}
+
+export function CallButton({ conversationId, contactPhone, contactName }: CallButtonProps) {
+    const { callState, activeCallId, setOutgoingCall, setError, setCallContext, setMicStream } = useCallStore();
+    const { initiateCall } = useWebRTCCall();
+    const requestOutboundCall = useMutation(api.calls.requestOutboundCall);
+
+    const isInCall = callState === 'connecting' || callState === 'connected';
+    const isRinging = callState === 'ringing';
+    const isRequesting = callState === 'requesting_permission';
+    const isDialing = callState === 'dialing';
+    const isPermissionGranted = callState === 'permission_granted';
+    const isError = callState === 'error';
+    const isBusy = isInCall || isRinging || isRequesting || isDialing || isPermissionGranted;
+
+    const handleClick = async () => {
+        if (isBusy) return;
+        if (!conversationId || !contactPhone) return;
+
+        // Pre-record the conversation context in the store so the error bar
+        // (and its "Autoriser le microphone" retry button) has the data it
+        // needs to restart the call after the user fixes the issue.
+        setCallContext(
+            { name: contactName, phone: contactPhone },
+            conversationId as Id<"conversations">,
+        );
+
+        // Trigger the native mic prompt synchronously in the click handler so
+        // Chrome shows its own permission dialog immediately. Any later prompt
+        // (inside an async backend round-trip) would feel disconnected from
+        // the user's click.
+        //
+        // IMPORTANT: we keep the stream alive (do NOT stop tracks here) and
+        // store it in the Zustand store. initiateCall() will run inside a
+        // useEffect (outside a user gesture), where Chrome on non-HTTPS origins
+        // would refuse a second getUserMedia. Reusing the pre-acquired stream
+        // bypasses that restriction entirely.
+        let micStream: MediaStream;
+        try {
+            micStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            console.log('[call-flow] CallButton: getUserMedia granted, keeping stream alive for initiateCall');
+            setMicStream(micStream);
+        } catch (error) {
+            const errName = (error as DOMException)?.name ?? String(error);
+            console.warn('[call-flow] CallButton: getUserMedia failed', errName);
+            setError(mapCallError(errName));
+            return;
+        }
+
+        try {
+            console.log('[call-flow] CallButton: calling requestOutboundCall', { conversationId });
+            const result = await requestOutboundCall({
+                conversationId: conversationId as Id<"conversations">,
+            });
+
+            console.log('[call-flow] CallButton: requestOutboundCall result', {
+                callId: result.callId,
+                permissionAlreadyGranted: result.permissionAlreadyGranted,
+            });
+
+            if (result.callId) {
+                setOutgoingCall(
+                    result.callId,
+                    { name: contactName, phone: contactPhone },
+                    conversationId as Id<"conversations">,
+                );
+
+                if (result.permissionAlreadyGranted) {
+                    console.log('[call-flow] CallButton: permission already granted, calling initiateCall inline');
+                    try {
+                        await initiateCall(result.callId as Id<"calls">);
+                    } catch (error) {
+                        console.error('[call-flow] CallButton: initiateCall failed', error);
+                        setError(mapCallError(String(error)));
+                    }
+                }
+            }
+        } catch (error) {
+            console.error('[call-flow] CallButton: requestOutboundCall failed', error);
+            setError(mapCallError(String(error)));
+        }
+    };
+
+    // Icon and tooltip based on state
+    let tooltip: string;
+    let icon: React.ReactNode;
+    let iconColor = 'text-gray-500 hover:text-gray-700';
+
+    if (isInCall) {
+        tooltip = 'Appel en cours';
+        icon = <PhoneCall className="h-5 w-5" />;
+        iconColor = 'text-green-600';
+    } else if (isRinging) {
+        tooltip = 'Appel entrant...';
+        icon = <PhoneCall className="h-5 w-5 animate-pulse" />;
+        iconColor = 'text-green-600';
+    } else if (isRequesting || isPermissionGranted) {
+        tooltip = 'Demande en cours...';
+        icon = <Loader2 className="h-5 w-5 animate-spin" />;
+        iconColor = 'text-yellow-600';
+    } else if (isDialing) {
+        tooltip = 'Appel en cours...';
+        icon = <Loader2 className="h-5 w-5 animate-spin" />;
+        iconColor = 'text-blue-600';
+    } else if (isError) {
+        tooltip = 'Reessayer l\'appel';
+        icon = <AlertCircle className="h-5 w-5" />;
+        iconColor = 'text-red-500 hover:text-red-700';
+    } else {
+        tooltip = 'Appel audio';
+        icon = <Phone className="h-5 w-5" />;
+    }
+
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    className={iconColor}
+                    onClick={handleClick}
+                    disabled={isBusy && !isError}
+                >
+                    {icon}
+                </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+                <p>{tooltip}</p>
+            </TooltipContent>
+        </Tooltip>
+    );
+}

--- a/components/calls/call-error-action-button.test.tsx
+++ b/components/calls/call-error-action-button.test.tsx
@@ -1,0 +1,155 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock next/link so the dispatcher button renders a plain <a> we can assert on.
+vi.mock('next/link', () => ({
+    default: ({ href, children, ...rest }: { href: string; children: React.ReactNode } & Record<string, unknown>) => (
+        <a href={href} {...rest}>{children}</a>
+    ),
+}));
+
+// Mock convex/react so CallErrorActionButton's useMutation import does not
+// attempt a real network round-trip during the test.
+vi.mock('convex/react', () => ({
+    useMutation: () => vi.fn(),
+}));
+
+vi.mock('@/convex/_generated/api', () => ({
+    api: { calls: { requestOutboundCall: 'calls:requestOutboundCall' } },
+}));
+
+// Mock the WebRTC hook — only `initiateCall` is read by the retry branch.
+vi.mock('@/hooks/use-webrtc-call', () => ({
+    useWebRTCCall: () => ({ initiateCall: vi.fn() }),
+}));
+
+// Mock the mic-permission child to a trivial placeholder: we don't need to
+// exercise its internal mic retry logic in this test.
+vi.mock('./mic-permission-button', () => ({
+    MicPermissionButton: () => <button>Autoriser le microphone</button>,
+}));
+
+import { CallErrorActionButton } from './call-error-action-button';
+import { useCallStore } from '@/lib/stores/call-store';
+import { mapCallError } from './call-error-messages';
+
+afterEach(() => {
+    cleanup();
+});
+
+beforeEach(() => {
+    // Reset the Zustand store before each test so state does not leak between
+    // assertions. setState with `true` replaces the whole state.
+    useCallStore.setState({
+        activeCallId: null,
+        callState: 'idle',
+        contactName: null,
+        contactPhone: null,
+        callDirection: 'INBOUND',
+        callStartedAt: null,
+        isMuted: false,
+        conversationId: null,
+        errorMessage: null,
+        errorAction: null,
+        micStream: null,
+    });
+});
+
+describe('CallErrorActionButton — contextual fix-it buttons', () => {
+    it('renders "Reconnecter WhatsApp" link for reconnect-whatsapp action', () => {
+        // Simulate the exact state produced by the provider when the backend
+        // reports "CPR failed: 401 - code 190" (expired WhatsApp token).
+        const mapped = mapCallError(
+            'CPR failed: 401 - {"error":{"message":"Authentication Error","code":190,"type":"OAuthException","fbtrace_id":"Ab12Cd"}}',
+        );
+
+        // Sanity check — if this ever fails, the mapping regressed and the
+        // whole downstream UI will too.
+        expect(mapped.action).toEqual({ type: 'reconnect-whatsapp' });
+
+        useCallStore.setState({
+            callState: 'error',
+            errorMessage: mapped.message,
+            errorAction: mapped.action ?? null,
+        });
+
+        render(<CallErrorActionButton />);
+
+        const link = screen.getByRole('link', { name: /Reconnecter WhatsApp/i });
+        expect(link).toBeInTheDocument();
+        expect(link).toHaveAttribute('href', '/dashboard/settings?tab=channels');
+    });
+
+    it('renders nothing when there is no errorAction', () => {
+        useCallStore.setState({
+            callState: 'error',
+            errorMessage: 'Some error',
+            errorAction: null,
+        });
+
+        const { container } = render(<CallErrorActionButton />);
+        expect(container.firstChild).toBeNull();
+    });
+
+    it('renders the mic permission button for action type "mic"', () => {
+        useCallStore.setState({
+            callState: 'error',
+            errorMessage: "Autorisez l'acces au microphone pour passer des appels.",
+            errorAction: { type: 'mic' },
+        });
+
+        render(<CallErrorActionButton />);
+
+        expect(
+            screen.getByRole('button', { name: /Autoriser le microphone/i }),
+        ).toBeInTheDocument();
+    });
+
+    it('renders an external link for action type "external"', () => {
+        useCallStore.setState({
+            callState: 'error',
+            errorMessage: 'Probleme de facturation WhatsApp.',
+            errorAction: {
+                type: 'external',
+                href: 'https://business.facebook.com/',
+                label: 'Ouvrir Meta Business',
+            },
+        });
+
+        render(<CallErrorActionButton />);
+
+        const link = screen.getByRole('link', { name: /Ouvrir Meta Business/i });
+        expect(link).toHaveAttribute('href', 'https://business.facebook.com/');
+        expect(link).toHaveAttribute('target', '_blank');
+        expect(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+    });
+
+    it('renders a signin link for action type "signin"', () => {
+        useCallStore.setState({
+            callState: 'error',
+            errorMessage: 'Votre session a expire. Reconnectez-vous.',
+            errorAction: { type: 'signin' },
+        });
+
+        render(<CallErrorActionButton />);
+
+        const link = screen.getByRole('link', { name: /Se reconnecter/i });
+        expect(link).toHaveAttribute('href', '/sign-in');
+    });
+
+    it('renders a send-template link for action type "send-template"', () => {
+        useCallStore.setState({
+            callState: 'error',
+            errorMessage: 'Ce contact doit vous avoir ecrit dans les dernieres 24 heures.',
+            errorAction: { type: 'send-template' },
+            // @ts-expect-error — Id type is opaque, ok for test fixture
+            conversationId: 'kconv_test_id',
+        });
+
+        render(<CallErrorActionButton />);
+
+        const link = screen.getByRole('link', { name: /Envoyer un modele/i });
+        expect(link.getAttribute('href')).toContain('kconv_test_id');
+        expect(link.getAttribute('href')).toContain('openTemplates=1');
+    });
+});

--- a/components/calls/call-error-action-button.tsx
+++ b/components/calls/call-error-action-button.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import Link from 'next/link';
+import { ExternalLink, RotateCcw, Link as LinkIcon, LogIn, MessageSquarePlus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useCallStore } from '@/lib/stores/call-store';
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
+import { useWebRTCCall } from '@/hooks/use-webrtc-call';
+import { mapCallError } from './call-error-messages';
+import { MicPermissionButton } from './mic-permission-button';
+
+/**
+ * Dispatcher: renders the right contextual action button based on the
+ * `errorAction` attached to the current error. One button per error type
+ * so non-technical users always have a clear next step.
+ */
+export function CallErrorActionButton() {
+    const action = useCallStore((s) => s.errorAction);
+    const conversationId = useCallStore((s) => s.conversationId);
+    const contactName = useCallStore((s) => s.contactName);
+    const contactPhone = useCallStore((s) => s.contactPhone);
+    const setError = useCallStore((s) => s.setError);
+    const setOutgoingCall = useCallStore((s) => s.setOutgoingCall);
+    const clearCall = useCallStore((s) => s.clearCall);
+    const { initiateCall } = useWebRTCCall();
+    const requestOutboundCall = useMutation(api.calls.requestOutboundCall);
+
+    if (!action) return null;
+
+    if (action.type === 'mic') {
+        return <MicPermissionButton />;
+    }
+
+    if (action.type === 'reconnect-whatsapp') {
+        return (
+            <Button
+                asChild
+                variant="outline"
+                size="sm"
+                className="gap-1 border-red-300 bg-white text-red-700 hover:bg-red-100"
+            >
+                <Link href="/dashboard/settings?tab=channels">
+                    <LinkIcon className="h-4 w-4" />
+                    Reconnecter WhatsApp
+                </Link>
+            </Button>
+        );
+    }
+
+    if (action.type === 'signin') {
+        return (
+            <Button
+                asChild
+                variant="outline"
+                size="sm"
+                className="gap-1 border-red-300 bg-white text-red-700 hover:bg-red-100"
+            >
+                <Link href="/sign-in">
+                    <LogIn className="h-4 w-4" />
+                    Se reconnecter
+                </Link>
+            </Button>
+        );
+    }
+
+    if (action.type === 'external') {
+        return (
+            <Button
+                asChild
+                variant="outline"
+                size="sm"
+                className="gap-1 border-red-300 bg-white text-red-700 hover:bg-red-100"
+            >
+                <a href={action.href} target="_blank" rel="noopener noreferrer">
+                    <ExternalLink className="h-4 w-4" />
+                    {action.label}
+                </a>
+            </Button>
+        );
+    }
+
+    if (action.type === 'send-template') {
+        const targetHref = conversationId
+            ? `/dashboard/conversations/${conversationId}?openTemplates=1`
+            : '/dashboard/conversations';
+        return (
+            <Button
+                asChild
+                variant="outline"
+                size="sm"
+                className="gap-1 border-red-300 bg-white text-red-700 hover:bg-red-100"
+            >
+                <Link href={targetHref}>
+                    <MessageSquarePlus className="h-4 w-4" />
+                    Envoyer un modele
+                </Link>
+            </Button>
+        );
+    }
+
+    if (action.type === 'retry') {
+        async function handleRetry() {
+            const currentConversationId = conversationId;
+            const currentContactName = contactName;
+            const currentContactPhone = contactPhone;
+            clearCall();
+            if (!currentConversationId || !currentContactPhone) return;
+            try {
+                const result = await requestOutboundCall({
+                    conversationId: currentConversationId as Id<"conversations">,
+                });
+                if (result.callId) {
+                    setOutgoingCall(
+                        result.callId,
+                        { name: currentContactName ?? undefined, phone: currentContactPhone },
+                        currentConversationId as Id<"conversations">,
+                    );
+                    if (result.permissionAlreadyGranted) {
+                        try {
+                            await initiateCall(result.callId as Id<"calls">);
+                        } catch (err) {
+                            setError(mapCallError(String(err)));
+                        }
+                    }
+                }
+            } catch (err) {
+                setError(mapCallError(String(err)));
+            }
+        }
+
+        return (
+            <Button
+                variant="outline"
+                size="sm"
+                className="gap-1 border-red-300 bg-white text-red-700 hover:bg-red-100"
+                onClick={handleRetry}
+            >
+                <RotateCcw className="h-4 w-4" />
+                Reessayer
+            </Button>
+        );
+    }
+
+    return null;
+}

--- a/components/calls/call-error-messages.test.ts
+++ b/components/calls/call-error-messages.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect } from 'vitest';
+import { mapCallError, mapCallErrorMessage } from '@/components/calls/call-error-messages';
+
+// ---------------------------------------------------------------------------
+// mapCallError — browser / WebRTC errors
+// ---------------------------------------------------------------------------
+
+describe('mapCallError() — browser / WebRTC errors', () => {
+    it('NotAllowedError -> message FR + action {type: "mic"}', () => {
+        const result = mapCallError('NotAllowedError');
+        expect(result.action).toEqual({ type: 'mic' });
+        expect(typeof result.message).toBe('string');
+        expect(result.message.length).toBeGreaterThan(0);
+    });
+
+    it('case-insensitive match on NotAllowedError', () => {
+        const result = mapCallError('notallowederror: The request is not allowed');
+        expect(result.action).toEqual({ type: 'mic' });
+    });
+
+    it('"permission dismissed" also maps to mic action', () => {
+        const result = mapCallError('permission dismissed by user');
+        expect(result.action).toEqual({ type: 'mic' });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// mapCallError — Meta OAuth errors (code 190)
+// ---------------------------------------------------------------------------
+
+describe('mapCallError() — Meta OAuth / token errors', () => {
+    it('"OAuthException code:190" -> action {type: "reconnect-whatsapp"}', () => {
+        const result = mapCallError('OAuthException code:190');
+        expect(result.action).toEqual({ type: 'reconnect-whatsapp' });
+    });
+
+    it('"invalid oauth access token" -> reconnect-whatsapp', () => {
+        const result = mapCallError('invalid oauth access token');
+        expect(result.action).toEqual({ type: 'reconnect-whatsapp' });
+    });
+
+    it('"access token has expired" -> reconnect-whatsapp', () => {
+        const result = mapCallError('access token has expired');
+        expect(result.action).toEqual({ type: 'reconnect-whatsapp' });
+    });
+
+    it('exact Meta 401 payload as stored by backend -> reconnect-whatsapp', () => {
+        // This is the literal terminationReason written by
+        // convex/call_actions.ts::sendCallPermissionRequest when Meta returns
+        // 401 for an expired token. The UI flow depends on this mapping.
+        const raw = `CPR failed: 401 - {"error":{"message":"Authentication Error","code":190,"type":"OAuthException","fbtrace_id":"Ab12CdEf"}}`;
+        const result = mapCallError(raw);
+        expect(result.action).toEqual({ type: 'reconnect-whatsapp' });
+        expect(result.message).toMatch(/connexion whatsapp/i);
+    });
+
+    it('exact Meta 401 payload for outbound offer -> reconnect-whatsapp', () => {
+        // Same shape, different prefix (sendOutboundCallOffer path).
+        const raw = `Outbound offer failed: Error: Meta API error: 401 - {"error":{"message":"Authentication Error","code":190,"type":"OAuthException","fbtrace_id":"Ab12CdEf"}}`;
+        const result = mapCallError(raw);
+        expect(result.action).toEqual({ type: 'reconnect-whatsapp' });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// mapCallError — 24h messaging window (131047 / re-engagement)
+// ---------------------------------------------------------------------------
+
+describe('mapCallError() — 24h messaging window', () => {
+    it('"131047 re-engagement" -> action {type: "send-template"}', () => {
+        const result = mapCallError('131047 re-engagement required');
+        expect(result.action).toEqual({ type: 'send-template' });
+    });
+
+    it('"131050" alone -> send-template', () => {
+        const result = mapCallError('error 131050');
+        expect(result.action).toEqual({ type: 'send-template' });
+    });
+
+    it('"outside of the allowed window" -> send-template', () => {
+        const result = mapCallError('Message failed: outside of the allowed window');
+        expect(result.action).toEqual({ type: 'send-template' });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// mapCallError — billing (131044)
+// ---------------------------------------------------------------------------
+
+describe('mapCallError() — billing errors', () => {
+    it('"131044 billing" -> action {type: "external"} pointing to Meta Business', () => {
+        const result = mapCallError('131044 billing issue');
+        expect(result.action).toEqual({
+            type: 'external',
+            href: 'https://business.facebook.com/',
+            label: expect.any(String),
+        });
+    });
+
+    it('"payment" keyword -> external Meta Business action', () => {
+        const result = mapCallError('payment required');
+        expect(result.action).toEqual(
+            expect.objectContaining({ type: 'external', href: 'https://business.facebook.com/' }),
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// mapCallError — null / undefined fallback
+// ---------------------------------------------------------------------------
+
+describe('mapCallError() — null / undefined fallback', () => {
+    it('null -> action {type: "retry"}', () => {
+        const result = mapCallError(null);
+        expect(result.action).toEqual({ type: 'retry' });
+        expect(typeof result.message).toBe('string');
+        expect(result.message.length).toBeGreaterThan(0);
+    });
+
+    it('undefined -> action {type: "retry"}', () => {
+        const result = mapCallError(undefined);
+        expect(result.action).toEqual({ type: 'retry' });
+    });
+
+    it('empty string -> action {type: "retry"}', () => {
+        const result = mapCallError('');
+        expect(result.action).toEqual({ type: 'retry' });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// mapCallError — unknown / generic reason
+// ---------------------------------------------------------------------------
+
+describe('mapCallError() — unknown / generic errors', () => {
+    it('unknown backend error -> fallback message contains raw reason + action retry', () => {
+        const raw = 'some unknown backend error XYZ-999';
+        const result = mapCallError(raw);
+        expect(result.action).toEqual({ type: 'retry' });
+        // The raw reason (or a truncated version) should appear in the message
+        expect(result.message).toContain('XYZ-999');
+    });
+
+    it('long reason is truncated to 160 chars in the fallback message', () => {
+        const longReason = 'x'.repeat(200);
+        const result = mapCallError(longReason);
+        // Message should include the 160-char truncated form followed by "..."
+        expect(result.message).toContain('...');
+        // The raw portion embedded must not exceed 160 chars before the ellipsis
+        const embedded = result.message.replace(/^.*?: /, '');
+        expect(embedded.length).toBeLessThanOrEqual(163); // 160 + "..."
+    });
+});
+
+// ---------------------------------------------------------------------------
+// mapCallErrorMessage — string-only convenience wrapper
+// ---------------------------------------------------------------------------
+
+describe('mapCallErrorMessage()', () => {
+    it('returns the string message for NotAllowedError', () => {
+        const msg = mapCallErrorMessage('NotAllowedError');
+        expect(typeof msg).toBe('string');
+        expect(msg.length).toBeGreaterThan(0);
+        // Must be exactly the same as what mapCallError returns
+        expect(msg).toBe(mapCallError('NotAllowedError').message);
+    });
+
+    it('returns the string message for null', () => {
+        const msg = mapCallErrorMessage(null);
+        expect(typeof msg).toBe('string');
+        expect(msg).toBe(mapCallError(null).message);
+    });
+});

--- a/components/calls/call-error-messages.ts
+++ b/components/calls/call-error-messages.ts
@@ -1,0 +1,269 @@
+/**
+ * Maps backend `terminationReason` strings and browser WebRTC errors into
+ * user-friendly French messages AND an optional "fix-it" action that renders
+ * a contextual button in the error bar.
+ *
+ * Reference — Meta error codes encountered in practice:
+ *   - 190             : OAuth token expired / invalid / unparseable (needs reconnect)
+ *   - 131047 / 131050 : out of 24h messaging window (re-engagement required)
+ *   - 131044          : billing issue
+ *   - 131051          : unsupported message type
+ *   - 131056          : pair rate limit
+ *   - 138007          : no call capacity
+ *   - 10 / 200        : permission / scope missing
+ *   - 4  / 17 / 32    : application-level rate limit
+ *   - 368             : account restriction / violation
+ *
+ * Order matters: most specific matches first, generic fallback last.
+ */
+
+export type CallErrorAction =
+    /** Re-prompt the browser for microphone access */
+    | { type: "mic" }
+    /** Redirect the user to Parametres > Canaux to reconnect WhatsApp */
+    | { type: "reconnect-whatsapp" }
+    /** Retry the call (clears the error and lets the user click Appeler again) */
+    | { type: "retry" }
+    /** Session expired — redirect to sign-in */
+    | { type: "signin" }
+    /** Re-engagement: prompt the user to send a template message in this conversation */
+    | { type: "send-template" }
+    /** External link (e.g. Meta Business Manager) */
+    | { type: "external"; href: string; label: string };
+
+export interface CallErrorMessage {
+    message: string;
+    action?: CallErrorAction;
+}
+
+const RECONNECT_WHATSAPP: CallErrorAction = { type: "reconnect-whatsapp" };
+const RETRY: CallErrorAction = { type: "retry" };
+const MIC: CallErrorAction = { type: "mic" };
+const SIGNIN: CallErrorAction = { type: "signin" };
+const SEND_TEMPLATE: CallErrorAction = { type: "send-template" };
+const META_BUSINESS: CallErrorAction = {
+    type: "external",
+    href: "https://business.facebook.com/",
+    label: "Ouvrir Meta Business",
+};
+
+export function mapCallError(reason: string | undefined | null): CallErrorMessage {
+    if (typeof window !== "undefined") {
+        console.warn("[mapCallError] raw reason:", reason);
+    }
+
+    if (!reason) {
+        return {
+            message: "L'appel a echoue. Reessayez plus tard.",
+            action: RETRY,
+        };
+    }
+
+    const r = reason.toLowerCase();
+
+    // --- Browser / WebRTC errors (very specific signatures) ---
+    if (r.includes("notallowederror") || r.includes("permission dismissed")) {
+        return {
+            message: "Autorisez l'acces au microphone pour passer des appels.",
+            action: MIC,
+        };
+    }
+    if (r.includes("notfounderror") || r.includes("no audio device") || r.includes("devicenotfound")) {
+        return {
+            message: "Aucun microphone detecte sur cet appareil.",
+        };
+    }
+    if (r.includes("notreadableerror") || r.includes("trackstarterror")) {
+        return {
+            message: "Votre microphone est deja utilise par une autre application.",
+            action: RETRY,
+        };
+    }
+    if (r.includes("overconstrainederror")) {
+        return {
+            message: "Microphone incompatible. Essayez un autre peripherique audio.",
+        };
+    }
+
+    // --- Convex mutation guardrails ---
+    if (r.includes("cannot start call") || r.includes("expected permission_granted")) {
+        return {
+            message: "L'appel n'est plus disponible. Recommencez depuis le bouton Appeler.",
+            action: RETRY,
+        };
+    }
+    if (r.includes("contact has no phone")) {
+        return { message: "Ce contact n'a pas de numero de telephone valide." };
+    }
+    if (r.includes("not authenticated")) {
+        return {
+            message: "Votre session a expire. Reconnectez-vous.",
+            action: SIGNIN,
+        };
+    }
+
+    // --- Meta OAuth token / credentials problems ---
+    if (
+        r.includes("\"code\":190") ||
+        r.includes("(#190)") ||
+        r.includes("oauthexception") ||
+        r.includes("invalid oauth") ||
+        r.includes("cannot parse access token") ||
+        r.includes("access token has expired") ||
+        r.includes("session has expired") ||
+        r.includes("access token is invalid")
+    ) {
+        return {
+            message: "Votre connexion WhatsApp a expire. Reconnectez votre compte WhatsApp Business.",
+            action: RECONNECT_WHATSAPP,
+        };
+    }
+    if (r.includes("missing whatsapp credentials") || r.includes("credentials")) {
+        return {
+            message: "Configuration WhatsApp incomplete. Connectez votre compte WhatsApp Business.",
+            action: RECONNECT_WHATSAPP,
+        };
+    }
+    if (r.includes("\"code\":10") || r.includes("(#10)") || r.includes("permission scope")) {
+        return {
+            message: "Permissions WhatsApp manquantes. Reauthentifiez votre compte WhatsApp Business.",
+            action: RECONNECT_WHATSAPP,
+        };
+    }
+    if (r.includes("\"code\":200") || r.includes("(#200)")) {
+        return {
+            message: "Permissions insuffisantes. Reconnectez votre compte WhatsApp Business.",
+            action: RECONNECT_WHATSAPP,
+        };
+    }
+
+    // --- Calling feature not enabled on the phone number ---
+    if (
+        r.includes("calling is not enabled") ||
+        r.includes("calling_not_enabled") ||
+        r.includes("calling is disabled")
+    ) {
+        return {
+            message: "Les appels ne sont pas actives sur ce numero. Activez-les dans Parametres > Canaux.",
+            action: RECONNECT_WHATSAPP,
+        };
+    }
+
+    // --- 24h messaging window (CPR must be within active conversation) ---
+    if (
+        r.includes("131047") ||
+        r.includes("131050") ||
+        r.includes("re-engagement") ||
+        r.includes("reengagement") ||
+        r.includes("24 hour") ||
+        r.includes("24-hour") ||
+        r.includes("messaging window") ||
+        r.includes("message was sent to a recipient who has not opted in") ||
+        r.includes("outside of the allowed window")
+    ) {
+        return {
+            message:
+                "Ce contact doit vous avoir ecrit dans les dernieres 24 heures. Envoyez-lui un modele pour reouvrir la conversation.",
+            action: SEND_TEMPLATE,
+        };
+    }
+
+    // --- Billing / payment ---
+    if (r.includes("131044") || r.includes("(#131044)") || r.includes("payment") || r.includes("billing")) {
+        return {
+            message: "Probleme de facturation WhatsApp. Verifiez les paiements dans Meta Business Manager.",
+            action: META_BUSINESS,
+        };
+    }
+
+    // --- Rate limiting ---
+    if (
+        r.includes("131056") ||
+        r.includes("rate limit") ||
+        r.includes("is_transient") ||
+        r.includes("throttl") ||
+        r.includes("(#4)") ||
+        r.includes("(#17)") ||
+        r.includes("(#32)") ||
+        r.includes("too many requests")
+    ) {
+        return {
+            message: "Limite d'appels atteinte. Reessayez dans quelques minutes.",
+            action: RETRY,
+        };
+    }
+
+    // --- No call capacity ---
+    if (r.includes("138007") || r.includes("call capacity")) {
+        return {
+            message: "Capacite d'appels atteinte cote WhatsApp. Reessayez plus tard.",
+            action: RETRY,
+        };
+    }
+
+    // --- Account restriction / policy violation ---
+    if (r.includes("368") || r.includes("account restricted") || r.includes("policy violation")) {
+        return {
+            message: "Votre compte WhatsApp Business est restreint. Consultez Meta Business Manager.",
+            action: META_BUSINESS,
+        };
+    }
+
+    // --- Unsupported message type ---
+    if (r.includes("131051") || r.includes("unsupported message type")) {
+        return {
+            message: "Les appels ne sont pas disponibles pour ce contact (type de message non supporte).",
+        };
+    }
+
+    // --- CPR already sent (1/24h per contact, 2/7j max) ---
+    if (
+        (r.includes("already") && r.includes("permission")) ||
+        r.includes("one permission request") ||
+        r.includes("permission request limit")
+    ) {
+        return {
+            message: "Une demande d'appel a deja ete envoyee. Attendez sa reponse (max 1 par 24h).",
+        };
+    }
+
+    // --- Permission denied/rejected by the contact ---
+    if (r.includes("call_permission_request_rejected") || r.includes("permission_denied")) {
+        return { message: "Ce contact a refuse votre demande d'appel." };
+    }
+
+    // --- Internal expiry labels we store in terminationReason ---
+    if (r.includes("permission_expired")) {
+        return {
+            message: "La permission d'appel a expire (plus de 72 heures). Envoyez une nouvelle demande.",
+            action: RETRY,
+        };
+    }
+    if (r.includes("cpr_expired")) {
+        return {
+            message: "Ce contact n'a pas repondu a votre demande d'appel dans les 24 heures.",
+            action: RETRY,
+        };
+    }
+
+    // --- Blocked country (USA, Canada, Egypt, Vietnam, Nigeria, Turkey) ---
+    if (
+        r.includes("not supported in this country") ||
+        r.includes("country not supported") ||
+        r.includes("region not supported")
+    ) {
+        return { message: "Les appels ne sont pas disponibles dans le pays de ce contact." };
+    }
+
+    // --- Generic fallback — keep the raw reason for debugging ---
+    const truncated = reason.length > 160 ? reason.slice(0, 160) + "..." : reason;
+    return {
+        message: `L'appel a echoue : ${truncated}`,
+        action: RETRY,
+    };
+}
+
+/** Backwards-compatible string-only mapper (message field only). */
+export function mapCallErrorMessage(reason: string | undefined | null): string {
+    return mapCallError(reason).message;
+}

--- a/components/calls/call-notification-provider.tsx
+++ b/components/calls/call-notification-provider.tsx
@@ -1,0 +1,262 @@
+'use client';
+
+import { useQuery } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { useEffect, useRef } from 'react';
+import { useCurrentOrg } from '@/hooks/use-current-org';
+import { useCallStore } from '@/lib/stores/call-store';
+import { useWebRTCCall } from '@/hooks/use-webrtc-call';
+import { IncomingCallDialog } from './incoming-call-dialog';
+import { ActiveCallBar } from './active-call-bar';
+import { mapCallError } from './call-error-messages';
+import { resolveFallbackReason } from './fallback-reason';
+
+/**
+ * Logic-only provider that subscribes to active calls via useQuery.
+ * Mounted in the dashboard layout alongside BrowserNotifications.
+ *
+ * Handles both inbound and outbound call state transitions:
+ * - Inbound: detects RINGING -> shows IncomingCallDialog
+ * - Outbound: tracks REQUESTING_PERMISSION -> PERMISSION_GRANTED -> initiates WebRTC
+ */
+export function CallNotificationProvider() {
+    const { currentOrg } = useCurrentOrg();
+    const { callState, setIncomingCall, setCallState, setError, clearCall, activeCallId } = useCallStore();
+    const { applyRemoteSdpAnswer, initiateCall } = useWebRTCCall();
+
+    // Subscribe to active ringing calls for this org (inbound)
+    const activeCall = useQuery(
+        api.calls.getActiveCall,
+        currentOrg?._id ? { organizationId: currentOrg._id } : 'skip'
+    );
+
+    // Subscribe to the agent's own active call (PRE_ACCEPTED/CONNECTED)
+    const myActiveCall = useQuery(
+        api.calls.getMyActiveCall,
+        currentOrg?._id ? { organizationId: currentOrg._id } : 'skip'
+    );
+
+    // Subscribe to the agent's outbound call in progress
+    const myOutboundCall = useQuery(
+        api.calls.getMyOutboundCall,
+        currentOrg?._id ? { organizationId: currentOrg._id } : 'skip'
+    );
+
+    // Subscribe to the specific activeCallId so we can detect async failures
+    // (FAILED status + terminationReason) even after the call leaves the
+    // "in-progress" query result set.
+    const isOutboundPending = callState === 'requesting_permission' ||
+        callState === 'permission_granted' ||
+        callState === 'dialing' ||
+        callState === 'connecting';
+    const trackedCallStatus = useQuery(
+        api.calls.getCallStatusForAgent,
+        activeCallId && isOutboundPending ? { callId: activeCallId } : 'skip'
+    );
+
+    const lastCallIdRef = useRef<string | null>(null);
+    const lastOutboundStatusRef = useRef<string | null>(null);
+    const sdpAnswerAppliedRef = useRef<string | null>(null);
+    const reportedFailureRef = useRef<string | null>(null);
+    // Tracks the callId for which initiateCall is currently in-flight so that
+    // the PERMISSION_GRANTED+dialing re-fire guard doesn't trigger a false error.
+    const initiatingCallIdRef = useRef<string | null>(null);
+    // Mirror of trackedCallStatus so the fallback timer callback reads the
+    // freshest value at fire time (not the stale snapshot captured at effect
+    // setup). Without this, a backend-reported terminationReason (e.g.
+    // "CPR failed: 401 - code 190") can be masked by a generic fallback error.
+    const trackedCallStatusRef = useRef(trackedCallStatus);
+    useEffect(() => {
+        trackedCallStatusRef.current = trackedCallStatus;
+    }, [trackedCallStatus]);
+
+    // Detect new incoming calls
+    useEffect(() => {
+        if (!activeCall) {
+            if (callState === 'ringing' && activeCallId) {
+                clearCall();
+            }
+            lastCallIdRef.current = null;
+            return;
+        }
+
+        if (activeCall._id !== lastCallIdRef.current && callState === 'idle') {
+            lastCallIdRef.current = activeCall._id;
+            setIncomingCall(activeCall._id, {
+                name: activeCall.contact?.name,
+                phone: activeCall.fromPhone,
+            });
+
+            if (typeof window !== 'undefined' && 'Notification' in window && Notification.permission === 'granted') {
+                new Notification('Appel entrant', {
+                    body: `${activeCall.contact?.name || activeCall.fromPhone} vous appelle`,
+                    icon: '/favicon.ico',
+                    tag: `call-${activeCall._id}`,
+                });
+            }
+        }
+    }, [activeCall, callState, activeCallId, setIncomingCall, clearCall]);
+
+    // Detect when call was terminated remotely (webhook terminate)
+    useEffect(() => {
+        if (callState === 'connected' || callState === 'connecting') {
+            if (!myActiveCall) {
+                clearCall();
+            }
+        }
+    }, [myActiveCall, callState, clearCall]);
+
+    // Detect async terminal failures on the tracked call (CPR rejected, 24h window, etc.)
+    // This query stays live even after the call leaves `getMyOutboundCall` (FAILED/TERMINATED).
+    useEffect(() => {
+        if (!trackedCallStatus || !activeCallId) return;
+        if (trackedCallStatus.direction !== 'OUTBOUND') return;
+
+        const terminalStatuses = ['FAILED', 'TERMINATED', 'REJECTED', 'MISSED'];
+        if (!terminalStatuses.includes(trackedCallStatus.status)) return;
+
+        if (reportedFailureRef.current === activeCallId) return;
+        reportedFailureRef.current = activeCallId;
+
+        console.error(
+            '[call-flow] Provider: tracked call terminal status',
+            trackedCallStatus.status,
+            '| reason:',
+            trackedCallStatus.terminationReason
+        );
+        setError(mapCallError(trackedCallStatus.terminationReason));
+    }, [trackedCallStatus, activeCallId, setError]);
+
+    // Fallback timer: if the call disappears from `myOutboundCall` but the
+    // tracked-status effect never surfaces a terminal status within 5s, show
+    // an error so the user isn't stuck in a pending state forever. At fire
+    // time we re-read trackedCallStatusRef to prefer the real Meta reason
+    // (e.g. "CPR failed: 401 - code 190") over a generic fallback.
+    useEffect(() => {
+        if (myOutboundCall) return;
+        if (!activeCallId) return;
+        if (reportedFailureRef.current === activeCallId) return;
+        if (
+            callState !== 'requesting_permission' &&
+            callState !== 'permission_granted' &&
+            callState !== 'dialing'
+        ) {
+            return;
+        }
+
+        const timer = setTimeout(() => {
+            if (reportedFailureRef.current === activeCallId) return;
+            reportedFailureRef.current = activeCallId;
+            const reason = resolveFallbackReason(trackedCallStatusRef.current);
+            console.warn(
+                '[call-flow] Provider: fallback timer fired',
+                '| status:',
+                trackedCallStatusRef.current?.status ?? 'unknown',
+                '| reason:',
+                reason,
+            );
+            setError(mapCallError(reason));
+        }, 5000);
+
+        return () => clearTimeout(timer);
+    }, [myOutboundCall, activeCallId, callState, setError]);
+
+    // Track outbound call state transitions
+    useEffect(() => {
+        if (!myOutboundCall) {
+            // Call left the active-outbound query set — it moved to a terminal
+            // status. The tracked-status effect above surfaces the real reason;
+            // the fallback timer above handles the case where the status update
+            // never arrives. Don't overwrite the error here.
+            lastOutboundStatusRef.current = null;
+            return;
+        }
+
+        const status = myOutboundCall.status;
+
+        // Don't re-process the same status
+        if (status === lastOutboundStatusRef.current) return;
+        lastOutboundStatusRef.current = status;
+
+        if (status === 'PERMISSION_GRANTED' && callState === 'requesting_permission') {
+            setCallState('permission_granted');
+            console.log('[call-flow] Provider: PERMISSION_GRANTED detected, auto-initiating call', myOutboundCall._id);
+
+            if (typeof window !== 'undefined' && 'Notification' in window && Notification.permission === 'granted') {
+                new Notification('Permission accordee', {
+                    body: `${myOutboundCall.contact?.name || myOutboundCall.toPhone} a accepte votre demande d'appel`,
+                    icon: '/favicon.ico',
+                    tag: `call-permission-${myOutboundCall._id}`,
+                });
+            }
+
+            // Mark this call as in-flight before awaiting so the guard below
+            // doesn't treat the callState='dialing' re-render as a failure.
+            initiatingCallIdRef.current = myOutboundCall._id;
+
+            // Auto-initiate call immediately when permission is granted
+            initiateCall(myOutboundCall._id)
+                .then(() => {
+                    console.log('[call-flow] Provider: auto-initiateCall completed for', myOutboundCall._id);
+                })
+                .catch((err) => {
+                    console.error('[call-flow] Provider: auto-initiateCall failed', err);
+                    // If the tracked-call effect already surfaced a specific reason, don't override it.
+                    if (reportedFailureRef.current === myOutboundCall._id) return;
+                    setError(mapCallError(String(err)));
+                })
+                .finally(() => {
+                    if (initiatingCallIdRef.current === myOutboundCall._id) {
+                        initiatingCallIdRef.current = null;
+                    }
+                });
+        }
+
+        // Call failed with recoverable error → went back to PERMISSION_GRANTED while we were dialing.
+        // Guard: only fire if no initiateCall is currently in-flight for this call (avoid false positive
+        // caused by the setCallState('dialing') re-render triggering this branch).
+        if (
+            status === 'PERMISSION_GRANTED' &&
+            (callState === 'dialing' || callState === 'connecting') &&
+            initiatingCallIdRef.current !== myOutboundCall._id
+        ) {
+            console.warn('[call-flow] Provider: PERMISSION_GRANTED while dialing/connecting (no in-flight), surfacing error', (myOutboundCall as any).terminationReason);
+            setError(mapCallError((myOutboundCall as any).terminationReason));
+        }
+    }, [myOutboundCall, callState, activeCallId, setCallState, setError, initiateCall]);
+
+    // Reset the failure tracker whenever a fresh call is set as active
+    useEffect(() => {
+        if (!activeCallId) {
+            reportedFailureRef.current = null;
+            return;
+        }
+        if (reportedFailureRef.current && reportedFailureRef.current !== activeCallId) {
+            reportedFailureRef.current = null;
+        }
+    }, [activeCallId]);
+
+    // Apply SDP answer for outbound calls (Meta sends back answer via webhook)
+    useEffect(() => {
+        if (
+            myOutboundCall?.sdpAnswer &&
+            callState === 'dialing' &&
+            myOutboundCall.sdpAnswer !== sdpAnswerAppliedRef.current
+        ) {
+            sdpAnswerAppliedRef.current = myOutboundCall.sdpAnswer;
+            applyRemoteSdpAnswer(myOutboundCall.sdpAnswer);
+        }
+    }, [myOutboundCall?.sdpAnswer, callState, applyRemoteSdpAnswer]);
+
+    return (
+        <>
+            {/* Incoming call dialog (ringing state) */}
+            {callState === 'ringing' && activeCall?.sdpOffer && (
+                <IncomingCallDialog sdpOffer={activeCall.sdpOffer} />
+            )}
+
+            {/* Active call bar (connecting/connected/dialing/requesting/error state) */}
+            <ActiveCallBar />
+        </>
+    );
+}

--- a/components/calls/fallback-reason.test.ts
+++ b/components/calls/fallback-reason.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { resolveFallbackReason } from './fallback-reason';
+import { mapCallError } from './call-error-messages';
+
+// Regression target: the fallback timer in CallNotificationProvider used to
+// unconditionally call setError(mapCallError(null)) after 5s. When the real
+// Meta reason (e.g. "CPR failed: 401 - code 190") happened to land in the
+// same React batch, the generic error won and the user saw "L'appel a
+// echoue" instead of "Votre connexion WhatsApp a expire" + a Reconnecter
+// WhatsApp button. These tests lock the race-resolution contract.
+
+describe('resolveFallbackReason()', () => {
+    it('returns null when the tracked snapshot has not resolved yet', () => {
+        expect(resolveFallbackReason(null)).toBeNull();
+        expect(resolveFallbackReason(undefined)).toBeNull();
+    });
+
+    it('returns null when the status is non-terminal (still pending)', () => {
+        expect(
+            resolveFallbackReason({ status: 'REQUESTING_PERMISSION', terminationReason: null }),
+        ).toBeNull();
+        expect(
+            resolveFallbackReason({ status: 'PERMISSION_GRANTED', terminationReason: null }),
+        ).toBeNull();
+        expect(
+            resolveFallbackReason({ status: 'RINGING', terminationReason: 'ignored' }),
+        ).toBeNull();
+    });
+
+    it('returns the terminationReason when the status is FAILED', () => {
+        const reason = `CPR failed: 401 - {"error":{"message":"Authentication Error","code":190,"type":"OAuthException"}}`;
+        expect(
+            resolveFallbackReason({ status: 'FAILED', terminationReason: reason }),
+        ).toBe(reason);
+    });
+
+    it('returns the terminationReason for TERMINATED / REJECTED / MISSED', () => {
+        expect(
+            resolveFallbackReason({ status: 'TERMINATED', terminationReason: 'agent_hangup' }),
+        ).toBe('agent_hangup');
+        expect(
+            resolveFallbackReason({ status: 'REJECTED', terminationReason: 'rejected' }),
+        ).toBe('rejected');
+        expect(
+            resolveFallbackReason({ status: 'MISSED', terminationReason: 'missed' }),
+        ).toBe('missed');
+    });
+
+    it('returns null when the terminal status has no terminationReason', () => {
+        expect(resolveFallbackReason({ status: 'FAILED' })).toBeNull();
+        expect(
+            resolveFallbackReason({ status: 'FAILED', terminationReason: null }),
+        ).toBeNull();
+    });
+
+    // End-to-end: the resolved reason, piped through mapCallError, must
+    // produce the reconnect-whatsapp action for a token-expired payload.
+    it('composed with mapCallError -> reconnect-whatsapp for code 190 payload', () => {
+        const tracked = {
+            status: 'FAILED',
+            terminationReason: `CPR failed: 401 - {"error":{"message":"Authentication Error","code":190,"type":"OAuthException","fbtrace_id":"Abc123"}}`,
+        };
+        const reason = resolveFallbackReason(tracked);
+        const mapped = mapCallError(reason);
+        expect(mapped.action).toEqual({ type: 'reconnect-whatsapp' });
+    });
+
+    // End-to-end: a pending (non-terminal) tracked snapshot yields the
+    // generic retry message (not a specific one) — correct behavior.
+    it('composed with mapCallError -> retry fallback when tracked is pending', () => {
+        const tracked = { status: 'REQUESTING_PERMISSION', terminationReason: null };
+        const reason = resolveFallbackReason(tracked);
+        const mapped = mapCallError(reason);
+        expect(mapped.action).toEqual({ type: 'retry' });
+    });
+});

--- a/components/calls/fallback-reason.ts
+++ b/components/calls/fallback-reason.ts
@@ -1,0 +1,40 @@
+/**
+ * Shared logic for the fallback timer in CallNotificationProvider.
+ *
+ * When an outbound call leaves the `getMyOutboundCall` result set (because it
+ * reached a terminal status), the provider starts a 5s timer as a safety net
+ * against the primary `trackedCallStatus` effect never firing. At timer fire
+ * time, we want to prefer the real Meta reason (e.g. "CPR failed: 401 - code
+ * 190") over a generic fallback — if the tracked status has already landed by
+ * then, we should use it.
+ *
+ * Extracted into a pure function so the tricky race-resolution contract can be
+ * unit-tested without spinning up Convex + React.
+ */
+
+type TerminalStatus = 'FAILED' | 'TERMINATED' | 'REJECTED' | 'MISSED';
+const TERMINAL_STATUSES: ReadonlySet<string> = new Set<TerminalStatus>([
+    'FAILED',
+    'TERMINATED',
+    'REJECTED',
+    'MISSED',
+]);
+
+export interface TrackedCallSnapshot {
+    status: string;
+    terminationReason?: string | null;
+}
+
+/**
+ * @param tracked The latest snapshot of `getCallStatusForAgent` (or null if
+ *                the query has not resolved yet).
+ * @returns The terminationReason to pass to `mapCallError`, or null to fall
+ *          back to the generic "L'appel a echoue" message.
+ */
+export function resolveFallbackReason(
+    tracked: TrackedCallSnapshot | null | undefined,
+): string | null {
+    if (!tracked) return null;
+    if (!TERMINAL_STATUSES.has(tracked.status)) return null;
+    return tracked.terminationReason ?? null;
+}

--- a/components/calls/incoming-call-dialog.tsx
+++ b/components/calls/incoming-call-dialog.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { Phone, PhoneOff, User } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useCallStore } from '@/lib/stores/call-store';
+import { useWebRTCCall } from '@/hooks/use-webrtc-call';
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { useState } from 'react';
+
+interface IncomingCallDialogProps {
+    sdpOffer: string;
+}
+
+export function IncomingCallDialog({ sdpOffer }: IncomingCallDialogProps) {
+    const { activeCallId, callState, contactName, contactPhone } = useCallStore();
+    const { answerCall, remoteAudioRef } = useWebRTCCall();
+    const rejectCallMutation = useMutation(api.calls.rejectCall);
+    const [isAccepting, setIsAccepting] = useState(false);
+
+    if (callState !== 'ringing' || !activeCallId) return null;
+
+    const displayName = contactName || contactPhone || 'Inconnu';
+
+    const handleAccept = async () => {
+        if (!activeCallId || isAccepting) return;
+        setIsAccepting(true);
+        try {
+            await answerCall(activeCallId, sdpOffer);
+        } catch (error) {
+            console.error('Failed to accept call:', error);
+            setIsAccepting(false);
+        }
+    };
+
+    const handleReject = async () => {
+        if (!activeCallId) return;
+        try {
+            await rejectCallMutation({ callId: activeCallId });
+        } catch (error) {
+            console.error('Failed to reject call:', error);
+        }
+    };
+
+    return (
+        <>
+            {/* Hidden audio element for remote audio playback */}
+            <audio ref={remoteAudioRef} autoPlay playsInline />
+
+            {/* Full-screen overlay */}
+            <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+                <div className="flex w-80 flex-col items-center gap-6 rounded-2xl bg-white p-8 shadow-2xl dark:bg-zinc-900">
+                    {/* Caller avatar */}
+                    <div className="flex h-20 w-20 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/30">
+                        <User className="h-10 w-10 text-green-600 dark:text-green-400" />
+                    </div>
+
+                    {/* Caller info */}
+                    <div className="text-center">
+                        <h3 className="text-lg font-semibold text-zinc-900 dark:text-zinc-100">
+                            {displayName}
+                        </h3>
+                        {contactName && contactPhone && (
+                            <p className="text-sm text-zinc-500">{contactPhone}</p>
+                        )}
+                        <p className="mt-1 animate-pulse text-sm text-green-600 dark:text-green-400">
+                            Appel entrant...
+                        </p>
+                    </div>
+
+                    {/* Action buttons */}
+                    <div className="flex gap-6">
+                        <Button
+                            variant="destructive"
+                            size="lg"
+                            className="h-14 w-14 rounded-full p-0"
+                            onClick={handleReject}
+                        >
+                            <PhoneOff className="h-6 w-6" />
+                        </Button>
+
+                        <Button
+                            size="lg"
+                            className="h-14 w-14 rounded-full bg-green-600 p-0 hover:bg-green-700"
+                            onClick={handleAccept}
+                            disabled={isAccepting}
+                        >
+                            <Phone className="h-6 w-6" />
+                        </Button>
+                    </div>
+                </div>
+            </div>
+        </>
+    );
+}

--- a/components/calls/mic-permission-button.tsx
+++ b/components/calls/mic-permission-button.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { useState } from 'react';
+import { Mic, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useCallStore } from '@/lib/stores/call-store';
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import type { Id } from '@/convex/_generated/dataModel';
+import { useWebRTCCall } from '@/hooks/use-webrtc-call';
+import { mapCallError } from './call-error-messages';
+
+/**
+ * One-click action: ask the browser for the microphone and, on success,
+ * immediately re-start the call so the user doesn't have to click again.
+ * If the browser has durably blocked the permission, surfaces a concrete
+ * error back to the user via the store (so the message & action update).
+ */
+export function MicPermissionButton() {
+    const conversationId = useCallStore((s) => s.conversationId);
+    const contactName = useCallStore((s) => s.contactName);
+    const contactPhone = useCallStore((s) => s.contactPhone);
+    const clearCall = useCallStore((s) => s.clearCall);
+    const setError = useCallStore((s) => s.setError);
+    const setMicStream = useCallStore((s) => s.setMicStream);
+    const setOutgoingCall = useCallStore((s) => s.setOutgoingCall);
+    const requestOutboundCall = useMutation(api.calls.requestOutboundCall);
+    const { initiateCall } = useWebRTCCall();
+    const [requesting, setRequesting] = useState(false);
+
+    async function handleClick() {
+        setRequesting(true);
+
+        const savedConversationId = conversationId;
+        const savedContactName = contactName;
+        const savedContactPhone = contactPhone;
+
+        let micStream: MediaStream;
+        try {
+            // Trigger the native browser prompt. Keep the stream alive so that
+            // initiateCall (running in a useEffect, not a user gesture) can reuse
+            // it without a second getUserMedia on non-HTTPS origins.
+            micStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            console.log('[call-flow] MicPermissionButton: getUserMedia granted, storing stream');
+        } catch (err) {
+            console.error('[MicPermissionButton] getUserMedia failed:', err);
+            setRequesting(false);
+
+            // If the permission is durably denied, query the Permissions API
+            // to confirm and surface a clearer error ("mic blocked by browser")
+            // rather than leaving the button looking inert.
+            try {
+                const status = await navigator.permissions.query({
+                    name: 'microphone' as PermissionName,
+                });
+                if (status.state === 'denied') {
+                    setError({
+                        message:
+                            "Votre navigateur a bloque le microphone pour ce site. Cliquez sur l'icone cadenas a gauche de l'URL pour l'autoriser.",
+                    });
+                    return;
+                }
+            } catch {
+                // Permissions API unavailable — fall through.
+            }
+
+            setError(mapCallError(String((err as Error)?.name ?? err)));
+            return;
+        }
+
+        // Mic granted — clear the stale error state FIRST (which stops any
+        // previous stream), THEN store the fresh live stream. Reversing the
+        // order would cause clearCall to immediately stop the tracks and null
+        // the ref we just set, leading initiateCall to fall back to a second
+        // getUserMedia outside the user gesture (NotAllowedError on http://).
+        clearCall();
+        setMicStream(micStream);
+
+        if (!savedConversationId || !savedContactPhone) {
+            // No context to restart — discard the stream and bail out.
+            console.warn('[call-flow] MicPermissionButton: missing conversationId or contactPhone after clearCall');
+            micStream.getTracks().forEach((t) => t.stop());
+            setMicStream(null);
+            setRequesting(false);
+            return;
+        }
+
+        try {
+            console.log('[call-flow] MicPermissionButton: calling requestOutboundCall', { savedConversationId });
+            const result = await requestOutboundCall({
+                conversationId: savedConversationId as Id<'conversations'>,
+            });
+            console.log('[call-flow] MicPermissionButton: requestOutboundCall result', {
+                callId: result.callId,
+                permissionAlreadyGranted: result.permissionAlreadyGranted,
+            });
+            if (result.callId) {
+                setOutgoingCall(
+                    result.callId,
+                    { name: savedContactName ?? undefined, phone: savedContactPhone },
+                    savedConversationId as Id<'conversations'>,
+                );
+                if (result.permissionAlreadyGranted) {
+                    console.log('[call-flow] MicPermissionButton: permission already granted, calling initiateCall inline');
+                    try {
+                        await initiateCall(result.callId as Id<'calls'>);
+                    } catch (err) {
+                        console.error('[call-flow] MicPermissionButton: initiateCall failed', err);
+                        setError(mapCallError(String(err)));
+                    }
+                }
+            }
+        } catch (err) {
+            console.error('[call-flow] MicPermissionButton: requestOutboundCall failed', err);
+            setError(mapCallError(String(err)));
+        } finally {
+            setRequesting(false);
+        }
+    }
+
+    return (
+        <Button
+            variant="outline"
+            size="sm"
+            className="gap-1 border-red-300 bg-white text-red-700 hover:bg-red-100"
+            onClick={handleClick}
+            disabled={requesting}
+        >
+            {requesting ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+                <Mic className="h-4 w-4" />
+            )}
+            Autoriser le microphone
+        </Button>
+    );
+}

--- a/components/conversations/ConversationView.tsx
+++ b/components/conversations/ConversationView.tsx
@@ -33,7 +33,6 @@ import { formatDistanceToNow, format, isToday, isYesterday, isSameDay } from 'da
 import { fr } from 'date-fns/locale'
 import {
     ArrowLeft,
-    Phone,
     MoreVertical,
     Info,
     Archive,
@@ -75,7 +74,7 @@ import { ForwardMessageModal } from './ForwardMessageModal'
 import { AssignmentBadge } from './AssignmentBadge'
 import { AssignmentDropdown } from './AssignmentDropdown'
 import { ButtonGroup } from '@/components/ui/button-group'
-// import { CallButton } from '@/components/calls/call-button' // Fonctionnalite d'appel audio desactivee temporairement
+import { CallButton } from '@/components/calls/call-button'
 import { useMessages, type Message } from '@/hooks/useMessages'
 import { useConversations } from '@/hooks/useConversations'
 import { useTypingIndicator } from '@/hooks/useRealtime'
@@ -301,22 +300,12 @@ function ConversationHeader({
                             onAssignmentChange={onAssignmentChange}
                         />
 
-                        {/* Appel audio - Bientot disponible */}
-                        <Tooltip>
-                            <TooltipTrigger asChild>
-                                <Button
-                                    variant="outline"
-                                    size="sm"
-                                    className="gap-1.5 text-gray-500 border-gray-200 bg-gray-50/50 cursor-not-allowed hover:bg-gray-50/50 hover:text-gray-500"
-                                >
-                                    <Phone className="h-4 w-4" />
-                                    <span className="hidden sm:inline">Bientot</span>
-                                </Button>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                                <p>Les appels audio seront bientot disponibles</p>
-                            </TooltipContent>
-                        </Tooltip>
+                        {/* Appel audio */}
+                        <CallButton
+                            conversationId={conversation.id}
+                            contactPhone={conversation.contact?.phone}
+                            contactName={conversation.contact?.name ?? undefined}
+                        />
                     </ButtonGroup>
                 )}
 

--- a/components/settings/ChannelsSettings.tsx
+++ b/components/settings/ChannelsSettings.tsx
@@ -84,6 +84,27 @@ export function ChannelsSettings() {
     const [tokenErrors, setTokenErrors] = useState<Record<string, string>>({})
     const [checkingTokens, setCheckingTokens] = useState(false)
 
+    // Real signal: read the calls history. Meta's read-scope health probe
+    // (getChannelStatus) can return "OK" when calling-specific scopes are
+    // already broken — so we also look at recent FAILED outbound calls with
+    // code 190 / OAuthException to surface the expired-token state that the
+    // probe misses.
+    const callsTokenIssues = useQuery(
+        api.calls.getChannelsWithTokenError,
+        currentOrg ? { organizationId: currentOrg._id } : "skip",
+    )
+
+    useEffect(() => {
+        if (!callsTokenIssues || callsTokenIssues.length === 0) return
+        setTokenErrors(prev => {
+            const next = { ...prev }
+            for (const issue of callsTokenIssues) {
+                next[issue.channelId as unknown as string] = issue.reason
+            }
+            return next
+        })
+    }, [callsTokenIssues])
+
     // Auto-check token health for all active channels on mount
     useEffect(() => {
         if (!channels.length || checkingTokens) return

--- a/components/settings/channel-health.test.ts
+++ b/components/settings/channel-health.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from 'vitest';
+import {
+    isTokenExpiredReason,
+    findChannelsWithTokenError,
+    DEFAULT_TOKEN_ERROR_WINDOW_MS,
+    type CallForHealthCheck,
+} from './channel-health';
+
+// Regression target: getChannelStatus reports OK (Meta's read-scope health
+// probe passes) but calling-specific scopes are missing. The agent then sees
+// "Quality GREEN + CONNECTED" in settings while outbound calls fail with
+// 401 code 190. These tests lock in the fallback detection path that reads
+// the real signal from the calls history.
+
+describe('isTokenExpiredReason()', () => {
+    it('returns false for null / undefined / empty', () => {
+        expect(isTokenExpiredReason(null)).toBe(false);
+        expect(isTokenExpiredReason(undefined)).toBe(false);
+        expect(isTokenExpiredReason('')).toBe(false);
+    });
+
+    it('detects exact Meta 401 CPR payload (code 190)', () => {
+        const raw = `CPR failed: 401 - {"error":{"message":"Authentication Error","code":190,"type":"OAuthException","fbtrace_id":"Abc123"}}`;
+        expect(isTokenExpiredReason(raw)).toBe(true);
+    });
+
+    it('detects exact Meta 401 outbound offer payload', () => {
+        const raw = `Outbound offer failed: Error: Meta API error: 401 - {"error":{"message":"Authentication Error","code":190,"type":"OAuthException"}}`;
+        expect(isTokenExpiredReason(raw)).toBe(true);
+    });
+
+    it('detects the human-readable (#190) form', () => {
+        expect(isTokenExpiredReason('Error validating access token (#190)')).toBe(true);
+    });
+
+    it('detects "access token has expired"', () => {
+        expect(isTokenExpiredReason('The access token has expired.')).toBe(true);
+    });
+
+    it('detects "session has been invalidated"', () => {
+        expect(isTokenExpiredReason('Session has been invalidated')).toBe(true);
+    });
+
+    it('is case-insensitive for OAuthException', () => {
+        expect(isTokenExpiredReason('OAUTHEXCEPTION thrown')).toBe(true);
+    });
+
+    it('returns false for unrelated errors', () => {
+        expect(isTokenExpiredReason('agent_hangup')).toBe(false);
+        expect(isTokenExpiredReason('call rejected by user')).toBe(false);
+        expect(isTokenExpiredReason('ICE connection failed')).toBe(false);
+    });
+});
+
+describe('findChannelsWithTokenError()', () => {
+    const now = 1_000_000_000_000; // deterministic
+    const ch1 = 'channel_1';
+    const ch2 = 'channel_2';
+
+    function mkCall(overrides: Partial<CallForHealthCheck>): CallForHealthCheck {
+        return {
+            whatsappChannelId: ch1,
+            status: 'FAILED',
+            terminationReason:
+                `CPR failed: 401 - {"error":{"message":"Authentication Error","code":190,"type":"OAuthException"}}`,
+            updatedAt: now - 60_000,
+            ...overrides,
+        };
+    }
+
+    it('returns empty array when no calls', () => {
+        expect(findChannelsWithTokenError([], now)).toEqual([]);
+    });
+
+    it('returns empty array when no calls match (no FAILED)', () => {
+        const calls = [mkCall({ status: 'TERMINATED' })];
+        expect(findChannelsWithTokenError(calls, now)).toEqual([]);
+    });
+
+    it('returns empty array when reason is not token-related', () => {
+        const calls = [mkCall({ terminationReason: 'agent_hangup' })];
+        expect(findChannelsWithTokenError(calls, now)).toEqual([]);
+    });
+
+    it('returns empty array when channel id is missing', () => {
+        const calls = [mkCall({ whatsappChannelId: null })];
+        expect(findChannelsWithTokenError(calls, now)).toEqual([]);
+    });
+
+    it('returns empty array when the last error is older than the window', () => {
+        const calls = [
+            mkCall({ updatedAt: now - DEFAULT_TOKEN_ERROR_WINDOW_MS - 1 }),
+        ];
+        expect(findChannelsWithTokenError(calls, now)).toEqual([]);
+    });
+
+    it('returns one entry per channel with matching FAILED call', () => {
+        const calls = [mkCall({})];
+        const result = findChannelsWithTokenError(calls, now);
+        expect(result).toHaveLength(1);
+        expect(result[0].channelId).toBe(ch1);
+        expect(result[0].reason).toContain('"code":190');
+    });
+
+    it('dedupes multiple failing calls for the same channel, keeping the most recent', () => {
+        const calls = [
+            mkCall({ updatedAt: now - 600_000 }),
+            mkCall({ updatedAt: now - 60_000 }),
+            mkCall({ updatedAt: now - 6_000_000 }),
+        ];
+        const result = findChannelsWithTokenError(calls, now);
+        expect(result).toHaveLength(1);
+        expect(result[0].lastErrorAt).toBe(now - 60_000);
+    });
+
+    it('returns one entry per distinct channel', () => {
+        const calls = [
+            mkCall({ whatsappChannelId: ch1 }),
+            mkCall({ whatsappChannelId: ch2, updatedAt: now - 10_000 }),
+        ];
+        const result = findChannelsWithTokenError(calls, now);
+        expect(result).toHaveLength(2);
+        const ids = result.map((r) => r.channelId).sort();
+        expect(ids).toEqual([ch1, ch2]);
+    });
+
+    it('does not flag a channel when a non-token FAILED call is the only match', () => {
+        const calls = [mkCall({ terminationReason: 'ICE failed' })];
+        expect(findChannelsWithTokenError(calls, now)).toEqual([]);
+    });
+
+    it('respects a custom window', () => {
+        const calls = [mkCall({ updatedAt: now - 20_000 })];
+        // Custom window of 10s — the call is 20s old, so it should be excluded.
+        expect(findChannelsWithTokenError(calls, now, 10_000)).toEqual([]);
+        // Custom window of 30s — the call fits.
+        expect(findChannelsWithTokenError(calls, now, 30_000)).toHaveLength(1);
+    });
+});

--- a/components/settings/channel-health.ts
+++ b/components/settings/channel-health.ts
@@ -1,0 +1,83 @@
+/**
+ * Shared logic for detecting channel-level token health issues from the
+ * calls history.
+ *
+ * Motivation: `getChannelStatus` (read-only Meta health check) returns OK for
+ * channels whose token still has read scopes but whose calling scopes have
+ * expired. The only reliable signal is the terminationReason of a recent
+ * FAILED outbound call. We extract the match into a pure function so the
+ * regex + window contract can be unit-tested without Convex.
+ */
+
+export interface CallForHealthCheck {
+    whatsappChannelId?: string | null;
+    status: string;
+    terminationReason?: string | null;
+    updatedAt: number;
+}
+
+export interface ChannelTokenIssue {
+    channelId: string;
+    lastErrorAt: number;
+    reason: string;
+}
+
+/**
+ * 24 hours in milliseconds. Used as the default freshness window for
+ * channel-level token error detection.
+ */
+export const DEFAULT_TOKEN_ERROR_WINDOW_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Heuristic: does the given terminationReason indicate a Meta auth failure
+ * (code 190, OAuthException, "access token has expired", etc.)?
+ *
+ * Mirrors the same signals used by `mapCallError` but returns a boolean
+ * instead of a user-facing message.
+ */
+export function isTokenExpiredReason(raw: string | null | undefined): boolean {
+    if (!raw) return false;
+    const r = raw.toLowerCase();
+    return (
+        r.includes('"code":190') ||
+        r.includes('(#190)') ||
+        r.includes('oauthexception') ||
+        r.includes('access token has expired') ||
+        r.includes('session has been invalidated') ||
+        r.includes('authentication error')
+    );
+}
+
+/**
+ * Given a list of recent calls, return one entry per channel that has at
+ * least one FAILED call with a token-expired terminationReason within the
+ * freshness window.
+ *
+ * The returned entry uses the *most recent* matching call for `lastErrorAt`
+ * and `reason`, so the UI can show a timestamp the user can act on.
+ */
+export function findChannelsWithTokenError(
+    calls: ReadonlyArray<CallForHealthCheck>,
+    now: number = Date.now(),
+    windowMs: number = DEFAULT_TOKEN_ERROR_WINDOW_MS,
+): ChannelTokenIssue[] {
+    const byChannel = new Map<string, ChannelTokenIssue>();
+
+    for (const call of calls) {
+        if (call.status !== 'FAILED') continue;
+        if (!call.whatsappChannelId) continue;
+        if (now - call.updatedAt > windowMs) continue;
+        if (!isTokenExpiredReason(call.terminationReason)) continue;
+
+        const existing = byChannel.get(call.whatsappChannelId);
+        if (!existing || existing.lastErrorAt < call.updatedAt) {
+            byChannel.set(call.whatsappChannelId, {
+                channelId: call.whatsappChannelId,
+                lastErrorAt: call.updatedAt,
+                reason: call.terminationReason ?? '',
+            });
+        }
+    }
+
+    return Array.from(byChannel.values());
+}

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -14,6 +14,8 @@ import type * as assignments from "../assignments.js";
 import type * as auth from "../auth.js";
 import type * as billing from "../billing.js";
 import type * as broadcasts from "../broadcasts.js";
+import type * as call_actions from "../call_actions.js";
+import type * as calls from "../calls.js";
 import type * as channels from "../channels.js";
 import type * as cleanup from "../cleanup.js";
 import type * as contacts from "../contacts.js";
@@ -123,6 +125,8 @@ declare const fullApi: ApiFromModules<{
   auth: typeof auth;
   billing: typeof billing;
   broadcasts: typeof broadcasts;
+  call_actions: typeof call_actions;
+  calls: typeof calls;
   channels: typeof channels;
   cleanup: typeof cleanup;
   contacts: typeof contacts;

--- a/convex/call_actions.ts
+++ b/convex/call_actions.ts
@@ -1,0 +1,394 @@
+"use node";
+
+/**
+ *   ____      _ _     _        _   _
+ *  / ___|__ _| | |   / \   ___| |_(_) ___  _ __  ___
+ * | |   / _` | | |  / _ \ / __| __| |/ _ \| '_ \/ __|
+ * | |__| (_| | | | / ___ \ (__| |_| | (_) | | | \__ \
+ *  \____\__,_|_|_|/_/   \_\___|\__|_|\___/|_| |_|___/
+ *
+ * META GRAPH API ACTIONS FOR WHATSAPP CALLING
+ *
+ * Sends call signaling commands (pre_accept, accept, reject, terminate)
+ * to Meta's WhatsApp Cloud API.
+ */
+
+import { v } from "convex/values";
+import { internalAction } from "./_generated/server";
+import { internal } from "./_generated/api";
+
+const GRAPH_API_VERSION = "v20.0";
+const GRAPH_API_BASE = `https://graph.facebook.com/${GRAPH_API_VERSION}`;
+
+/**
+ * Resolve WhatsApp credentials for a call.
+ * Priority: channel WABA config > org DB config > env vars.
+ */
+async function resolveCallCredentials(
+    ctx: any,
+    callId: any
+) {
+    const call = await ctx.runQuery(internal.utils.getCall, { id: callId });
+    if (!call) throw new Error(`Call ${callId} not found`);
+
+    const org = await ctx.runQuery(internal.utils.getOrganization, { id: call.organizationId });
+
+    let phoneNumberId: string | undefined;
+    let accessToken: string | undefined;
+
+    // Try channel-specific credentials first
+    if (call.whatsappChannelId) {
+        const channel = await ctx.runQuery(internal.utils.getWhatsAppChannel, { id: call.whatsappChannelId });
+        if (channel?.wabaId) {
+            const waba = await ctx.runQuery(internal.utils.getWaba, { id: channel.wabaId });
+            if (waba?.accessTokenRef) {
+                accessToken = waba.accessTokenRef;
+            }
+            phoneNumberId = channel.phoneNumberId;
+        }
+    }
+
+    // Fallback to org config
+    if (!phoneNumberId) phoneNumberId = org?.whatsapp?.phoneNumberId || process.env.WHATSAPP_PHONE_NUMBER_ID;
+    if (!accessToken) accessToken = org?.whatsapp?.accessToken || process.env.WHATSAPP_ACCESS_TOKEN;
+
+    if (!phoneNumberId || !accessToken) {
+        throw new Error(`Missing WhatsApp credentials for call ${callId}`);
+    }
+
+    return { call, phoneNumberId, accessToken };
+}
+
+/**
+ * Send a call action to Meta Graph API.
+ */
+async function sendCallAction(
+    phoneNumberId: string,
+    accessToken: string,
+    payload: Record<string, any>
+) {
+    const url = `${GRAPH_API_BASE}/${phoneNumberId}/calls`;
+
+    const response = await fetch(url, {
+        method: "POST",
+        headers: {
+            "Authorization": `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+            messaging_product: "whatsapp",
+            ...payload,
+        }),
+    });
+
+    const responseText = await response.text();
+
+    if (!response.ok) {
+        console.error(`[CALL_ACTION] API error ${response.status}:`, responseText);
+        throw new Error(`Meta API error: ${response.status} - ${responseText}`);
+    }
+
+    console.log(`[CALL_ACTION] Success:`, responseText);
+    return JSON.parse(responseText);
+}
+
+// ============================================
+// PRE_ACCEPT: Send SDP answer, begin WebRTC handshake
+// ============================================
+
+export const sendPreAccept = internalAction({
+    args: {
+        callId: v.id("calls"),
+    },
+    handler: async (ctx, args) => {
+        try {
+            const { call, phoneNumberId, accessToken } = await resolveCallCredentials(ctx, args.callId);
+
+            if (!call.sdpAnswer) {
+                throw new Error("No SDP answer available for pre_accept");
+            }
+
+            await sendCallAction(phoneNumberId, accessToken, {
+                call_id: call.externalCallId,
+                action: "pre_accept",
+                session: {
+                    sdp: call.sdpAnswer,
+                    sdp_type: "answer",
+                },
+            });
+
+            console.log(`[CALL_ACTION] pre_accept sent for call ${call.externalCallId}`);
+        } catch (error) {
+            console.error(`[CALL_ACTION] sendPreAccept failed:`, String(error));
+            await ctx.runMutation(internal.utils.updateCallStatus, {
+                callId: args.callId,
+                status: "FAILED",
+                terminationReason: `pre_accept failed: ${String(error)}`,
+            });
+        }
+    },
+});
+
+// ============================================
+// ACCEPT: Finalize the call after WebRTC connected
+// ============================================
+
+export const sendAccept = internalAction({
+    args: {
+        callId: v.id("calls"),
+    },
+    handler: async (ctx, args) => {
+        try {
+            const { call, phoneNumberId, accessToken } = await resolveCallCredentials(ctx, args.callId);
+
+            await sendCallAction(phoneNumberId, accessToken, {
+                call_id: call.externalCallId,
+                action: "accept",
+            });
+
+            console.log(`[CALL_ACTION] accept sent for call ${call.externalCallId}`);
+        } catch (error) {
+            console.error(`[CALL_ACTION] sendAccept failed:`, String(error));
+        }
+    },
+});
+
+// ============================================
+// REJECT: Decline the incoming call
+// ============================================
+
+export const sendReject = internalAction({
+    args: {
+        callId: v.id("calls"),
+    },
+    handler: async (ctx, args) => {
+        try {
+            const { call, phoneNumberId, accessToken } = await resolveCallCredentials(ctx, args.callId);
+
+            await sendCallAction(phoneNumberId, accessToken, {
+                call_id: call.externalCallId,
+                action: "reject",
+            });
+
+            console.log(`[CALL_ACTION] reject sent for call ${call.externalCallId}`);
+        } catch (error) {
+            console.error(`[CALL_ACTION] sendReject failed:`, String(error));
+        }
+    },
+});
+
+// ============================================
+// TERMINATE: End an active call
+// ============================================
+
+export const sendTerminate = internalAction({
+    args: {
+        callId: v.id("calls"),
+    },
+    handler: async (ctx, args) => {
+        try {
+            const { call, phoneNumberId, accessToken } = await resolveCallCredentials(ctx, args.callId);
+
+            await sendCallAction(phoneNumberId, accessToken, {
+                call_id: call.externalCallId,
+                action: "terminate",
+            });
+
+            console.log(`[CALL_ACTION] terminate sent for call ${call.externalCallId}`);
+        } catch (error) {
+            console.error(`[CALL_ACTION] sendTerminate failed:`, String(error));
+        }
+    },
+});
+
+// ============================================
+// ENABLE CALLING: Enable calling on a phone number
+// ============================================
+
+// ============================================
+// OUTBOUND: Send Call Permission Request (CPR)
+// ============================================
+
+export const sendCallPermissionRequest = internalAction({
+    args: {
+        callId: v.id("calls"),
+        organizationId: v.id("organizations"),
+        contactPhone: v.string(),
+    },
+    handler: async (ctx, args) => {
+        try {
+            const org = await ctx.runQuery(internal.utils.getOrganization, { id: args.organizationId });
+
+            // Resolve credentials (same priority as resolveCallCredentials)
+            const call = await ctx.runQuery(internal.utils.getCall, { id: args.callId });
+            if (!call) throw new Error(`Call ${args.callId} not found`);
+
+            let phoneNumberId: string | undefined;
+            let accessToken: string | undefined;
+
+            if (call.whatsappChannelId) {
+                const channel = await ctx.runQuery(internal.utils.getWhatsAppChannel, { id: call.whatsappChannelId });
+                if (channel?.wabaId) {
+                    const waba = await ctx.runQuery(internal.utils.getWaba, { id: channel.wabaId });
+                    if (waba?.accessTokenRef) accessToken = waba.accessTokenRef;
+                    phoneNumberId = channel.phoneNumberId;
+                }
+            }
+
+            if (!phoneNumberId) phoneNumberId = org?.whatsapp?.phoneNumberId || process.env.WHATSAPP_PHONE_NUMBER_ID;
+            if (!accessToken) accessToken = org?.whatsapp?.accessToken || process.env.WHATSAPP_ACCESS_TOKEN;
+
+            if (!phoneNumberId || !accessToken) {
+                throw new Error(`Missing WhatsApp credentials for CPR`);
+            }
+
+            // Update fromPhone on the call record
+            await ctx.runMutation(internal.utils.updateCallStatus, {
+                callId: args.callId,
+                status: "REQUESTING_PERMISSION",
+            });
+
+            const recipientPhone = args.contactPhone.replace(/\D/g, "");
+
+            // Send CPR as an interactive call_permission_request message
+            // This works within the 24-hour messaging window (active conversation)
+            const url = `${GRAPH_API_BASE}/${phoneNumberId}/messages`;
+            const payload = {
+                messaging_product: "whatsapp",
+                recipient_type: "individual",
+                to: recipientPhone,
+                type: "interactive",
+                interactive: {
+                    type: "call_permission_request",
+                    action: {
+                        name: "call_permission_request",
+                    },
+                    body: {
+                        text: "Nous souhaitons vous appeler concernant votre conversation.",
+                    },
+                },
+            };
+
+            const response = await fetch(url, {
+                method: "POST",
+                headers: {
+                    "Authorization": `Bearer ${accessToken}`,
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify(payload),
+            });
+
+            const responseText = await response.text();
+
+            if (!response.ok) {
+                console.error(`[CALL_ACTION] CPR failed ${response.status}:`, responseText);
+                await ctx.runMutation(internal.utils.updateCallStatus, {
+                    callId: args.callId,
+                    status: "FAILED",
+                    terminationReason: `CPR failed: ${response.status} - ${responseText}`,
+                });
+                return;
+            }
+
+            console.log(`[CALL_ACTION] CPR sent to ${recipientPhone}:`, responseText);
+        } catch (error) {
+            console.error(`[CALL_ACTION] sendCallPermissionRequest failed:`, String(error));
+            await ctx.runMutation(internal.utils.updateCallStatus, {
+                callId: args.callId,
+                status: "FAILED",
+                terminationReason: `CPR error: ${String(error)}`,
+            });
+        }
+    },
+});
+
+// ============================================
+// OUTBOUND: Send call offer with SDP to Meta
+// ============================================
+
+export const sendOutboundCallOffer = internalAction({
+    args: {
+        callId: v.id("calls"),
+    },
+    handler: async (ctx, args) => {
+        try {
+            const { call, phoneNumberId, accessToken } = await resolveCallCredentials(ctx, args.callId);
+
+            if (!call.sdpOffer) {
+                throw new Error("No SDP offer available for outbound call");
+            }
+
+            const recipientPhone = call.toPhone.replace(/\D/g, "");
+
+            const result = await sendCallAction(phoneNumberId, accessToken, {
+                to: recipientPhone,
+                session: {
+                    sdp: call.sdpOffer,
+                    sdp_type: "offer",
+                },
+            });
+
+            // Store the external call ID returned by Meta
+            if (result?.call_id) {
+                const callDoc = await ctx.runQuery(internal.utils.getCall, { id: args.callId });
+                if (callDoc) {
+                    await ctx.runMutation(internal.calls.updateExternalCallId, {
+                        callId: args.callId,
+                        externalCallId: result.call_id,
+                    });
+                }
+            }
+
+            console.log(`[CALL_ACTION] Outbound call offer sent to ${recipientPhone}`);
+        } catch (error) {
+            const errorStr = String(error);
+            console.error(`[CALL_ACTION] sendOutboundCallOffer failed:`, errorStr);
+
+            // Recoverable errors (payment, rate limit, transient) → back to PERMISSION_GRANTED so agent can retry
+            const isRecoverable = errorStr.includes("131044") || // payment issue
+                errorStr.includes("rate limit") ||
+                errorStr.includes("is_transient");
+
+            await ctx.runMutation(internal.utils.updateCallStatus, {
+                callId: args.callId,
+                status: isRecoverable ? "PERMISSION_GRANTED" : "FAILED",
+                terminationReason: `Outbound offer failed: ${errorStr}`,
+            });
+        }
+    },
+});
+
+// ============================================
+// ENABLE CALLING: Enable calling on a phone number
+// ============================================
+
+export const enableCallingOnChannel = internalAction({
+    args: {
+        phoneNumberId: v.string(),
+        accessToken: v.string(),
+    },
+    handler: async (ctx, args) => {
+        const url = `${GRAPH_API_BASE}/${args.phoneNumberId}/settings`;
+
+        const response = await fetch(url, {
+            method: "POST",
+            headers: {
+                "Authorization": `Bearer ${args.accessToken}`,
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify({
+                calling: { status: "ENABLED" },
+            }),
+        });
+
+        const responseText = await response.text();
+
+        if (!response.ok) {
+            console.error(`[CALL_ACTION] Enable calling failed ${response.status}:`, responseText);
+            throw new Error(`Failed to enable calling: ${response.status}`);
+        }
+
+        console.log(`[CALL_ACTION] Calling enabled on ${args.phoneNumberId}`);
+        return JSON.parse(responseText);
+    },
+});

--- a/convex/calls.ts
+++ b/convex/calls.ts
@@ -1,0 +1,876 @@
+/**
+ *   ____      _ _
+ *  / ___|__ _| | |___
+ * | |   / _` | | / __|
+ * | |__| (_| | | \__ \
+ *  \____\__,_|_|_|___/
+ *
+ * WHATSAPP BUSINESS CALLING API
+ *
+ * Handles inbound/outbound WhatsApp voice calls.
+ * Convex acts as a signaling relay between Meta and the agent's browser (WebRTC peer).
+ */
+
+import { internalMutation, mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+import { internal } from "./_generated/api";
+import { Id } from "./_generated/dataModel";
+import { getAuthUserId } from "@convex-dev/auth/server";
+
+// ============================================
+// WEBHOOK HANDLER (called from http.ts)
+// ============================================
+
+export const handleCallWebhook = internalMutation({
+    args: {
+        callId: v.string(),
+        from: v.string(),
+        to: v.string(),
+        event: v.string(),
+        direction: v.optional(v.string()),
+        sdp: v.optional(v.string()),
+        sdpType: v.optional(v.string()),
+        phoneNumberId: v.optional(v.string()),
+    },
+    handler: async (ctx, args) => {
+        const { callId, from, to, event, direction, sdp, sdpType, phoneNumberId } = args;
+
+        if (!phoneNumberId) {
+            console.error("[CALLS] Missing phoneNumberId in webhook event");
+            return;
+        }
+
+        // Resolve channel and organization (same pattern as webhook.ts)
+        const channel = await ctx.db
+            .query("whatsappChannels")
+            .withIndex("by_phone_id", (q) => q.eq("phoneNumberId", phoneNumberId))
+            .first();
+
+        let organizationId: Id<"organizations">;
+        let whatsappChannelId: Id<"whatsappChannels"> | undefined;
+
+        if (channel) {
+            if (channel.status !== "active") {
+                console.log(`[CALLS] Channel ${phoneNumberId} is ${channel.status}, skipping`);
+                return;
+            }
+            organizationId = channel.organizationId;
+            whatsappChannelId = channel._id;
+        } else {
+            const organization = await ctx.db
+                .query("organizations")
+                .withIndex("by_whatsapp_phone_id", (q) => q.eq("whatsapp.phoneNumberId", phoneNumberId))
+                .first();
+
+            if (!organization) {
+                console.error(`[CALLS] No channel or organization found for phoneNumberId: ${phoneNumberId}`);
+                return;
+            }
+            organizationId = organization._id;
+
+            const defaultChannel = await ctx.db
+                .query("whatsappChannels")
+                .withIndex("by_org_default", (q) => q.eq("organizationId", organizationId).eq("isOrgDefault", true))
+                .first();
+            whatsappChannelId = defaultChannel?._id;
+        }
+
+        // Handle different call events
+        if (event === "connect" && direction === "USER_INITIATED" && sdpType === "offer") {
+            // Inbound call: user is calling the business
+            await handleInboundCall(ctx, {
+                callId,
+                from,
+                to,
+                sdp: sdp || "",
+                organizationId,
+                whatsappChannelId,
+            });
+        } else if (event === "terminate") {
+            // Call terminated (either side hung up)
+            await handleCallTerminate(ctx, { callId });
+        } else if (event === "connect" && direction === "BUSINESS_INITIATED") {
+            // Outbound call: Meta sends SDP answer back
+            await handleOutboundCallUpdate(ctx, { callId, sdp, sdpType });
+        } else if (event === "permission_request_accepted") {
+            // User accepted the call permission request
+            await handlePermissionGranted(ctx, { from, to, phoneNumberId });
+        } else {
+            console.log(`[CALLS] Unhandled call event: ${event}, direction: ${direction}`);
+        }
+    },
+});
+
+async function handleInboundCall(
+    ctx: any,
+    args: {
+        callId: string;
+        from: string;
+        to: string;
+        sdp: string;
+        organizationId: Id<"organizations">;
+        whatsappChannelId?: Id<"whatsappChannels">;
+    }
+) {
+    const { callId, from, to, sdp, organizationId, whatsappChannelId } = args;
+
+    // Check for duplicate (idempotency)
+    const existing = await ctx.db
+        .query("calls")
+        .withIndex("by_external_call_id", (q: any) => q.eq("externalCallId", callId))
+        .first();
+    if (existing) {
+        console.log(`[CALLS] Duplicate call event for ${callId}, skipping`);
+        return;
+    }
+
+    // Find or create contact
+    let contact = await ctx.db
+        .query("contacts")
+        .withIndex("by_org_phone", (q: any) =>
+            q.eq("organizationId", organizationId).eq("phone", from)
+        )
+        .first();
+
+    if (!contact) {
+        const contactId = await ctx.db.insert("contacts", {
+            organizationId,
+            phone: from,
+            name: from,
+            searchName: from,
+            isWhatsApp: true,
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+        });
+        contact = await ctx.db.get(contactId);
+    }
+
+    if (!contact) throw new Error("Failed to get contact");
+
+    // Find open conversation for this contact
+    let conversation = await ctx.db
+        .query("conversations")
+        .withIndex("by_org_contact", (q: any) =>
+            q.eq("organizationId", organizationId)
+                .eq("contactId", contact!._id)
+                .eq("status", "OPEN")
+        )
+        .first();
+
+    if (!conversation) {
+        const conversationId = await ctx.db.insert("conversations", {
+            organizationId,
+            contactId: contact._id,
+            status: "OPEN",
+            unreadCount: 0,
+            lastMessageAt: Date.now(),
+            channel: "WHATSAPP",
+            whatsappChannelId,
+            createdAt: Date.now(),
+            updatedAt: Date.now(),
+        });
+        conversation = await ctx.db.get(conversationId);
+    }
+
+    // Insert the call record
+    const now = Date.now();
+    await ctx.db.insert("calls", {
+        organizationId,
+        conversationId: conversation?._id,
+        contactId: contact._id,
+        whatsappChannelId,
+        externalCallId: callId,
+        direction: "INBOUND" as const,
+        fromPhone: from,
+        toPhone: to,
+        sdpOffer: sdp,
+        status: "RINGING" as const,
+        startedAt: now,
+        createdAt: now,
+        updatedAt: now,
+    });
+
+    console.log(`[CALLS] Inbound call ${callId} from ${from} - RINGING`);
+}
+
+async function handleCallTerminate(ctx: any, args: { callId: string }) {
+    const call = await ctx.db
+        .query("calls")
+        .withIndex("by_external_call_id", (q: any) => q.eq("externalCallId", args.callId))
+        .first();
+
+    if (!call) {
+        console.log(`[CALLS] Terminate for unknown call ${args.callId}`);
+        return;
+    }
+
+    if (call.status === "TERMINATED" || call.status === "REJECTED" || call.status === "MISSED") {
+        return; // Already ended
+    }
+
+    const now = Date.now();
+    const durationSeconds = call.answeredAt
+        ? Math.round((now - call.answeredAt) / 1000)
+        : undefined;
+
+    await ctx.db.patch(call._id, {
+        status: "TERMINATED" as const,
+        endedAt: now,
+        durationSeconds,
+        terminationReason: "remote_hangup",
+        updatedAt: now,
+    });
+
+    // Insert system message into conversation
+    if (call.conversationId) {
+        const durationStr = durationSeconds
+            ? `${Math.floor(durationSeconds / 60)}:${String(durationSeconds % 60).padStart(2, "0")}`
+            : null;
+
+        const content = call.status === "CONNECTED" || call.answeredAt
+            ? `Appel audio - ${durationStr}`
+            : "Appel manque";
+
+        await ctx.db.insert("messages", {
+            organizationId: call.organizationId,
+            conversationId: call.conversationId,
+            contactId: call.contactId,
+            type: "SYSTEM",
+            content,
+            direction: "INBOUND",
+            status: "DELIVERED",
+            createdAt: now,
+            updatedAt: now,
+        });
+
+        // Update conversation
+        await ctx.db.patch(call.conversationId, {
+            lastMessageAt: now,
+            preview: content,
+            updatedAt: now,
+        });
+    }
+
+    console.log(`[CALLS] Call ${args.callId} terminated (duration: ${durationSeconds}s)`);
+}
+
+async function handleOutboundCallUpdate(
+    ctx: any,
+    args: { callId: string; sdp?: string; sdpType?: string }
+) {
+    const call = await ctx.db
+        .query("calls")
+        .withIndex("by_external_call_id", (q: any) => q.eq("externalCallId", args.callId))
+        .first();
+
+    if (!call) {
+        console.log(`[CALLS] Update for unknown outbound call ${args.callId}`);
+        return;
+    }
+
+    // If Meta sends back an SDP answer, store it for the browser to pick up
+    if (args.sdp && args.sdpType === "answer") {
+        await ctx.db.patch(call._id, {
+            sdpAnswer: args.sdp,
+            updatedAt: Date.now(),
+        });
+    }
+}
+
+async function handlePermissionGranted(
+    ctx: any,
+    args: { from: string; to: string; phoneNumberId: string }
+) {
+    // Find the REQUESTING_PERMISSION call for this contact
+    // The "from" is the user (contact), "to" is the business number
+    const calls = await ctx.db
+        .query("calls")
+        .filter((q: any) =>
+            q.and(
+                q.eq(q.field("toPhone"), args.from),
+                q.eq(q.field("direction"), "OUTBOUND"),
+                q.eq(q.field("status"), "REQUESTING_PERMISSION"),
+            )
+        )
+        .collect();
+
+    if (calls.length === 0) {
+        console.log(`[CALLS] Permission granted but no pending call found for ${args.from}`);
+        return;
+    }
+
+    // Take the most recent one
+    const call = calls[calls.length - 1];
+
+    await ctx.db.patch(call._id, {
+        status: "PERMISSION_GRANTED" as const,
+        updatedAt: Date.now(),
+    });
+
+    console.log(`[CALLS] Permission granted for call ${call._id} to ${args.from}`);
+}
+
+// ============================================
+// QUERIES (reactive subscriptions for UI)
+// ============================================
+
+export const getActiveCall = query({
+    args: {
+        organizationId: v.id("organizations"),
+    },
+    handler: async (ctx, args) => {
+        // Find any ringing call for this org
+        const call = await ctx.db
+            .query("calls")
+            .withIndex("by_org_status", (q) =>
+                q.eq("organizationId", args.organizationId).eq("status", "RINGING")
+            )
+            .first();
+
+        if (!call) return null;
+
+        const contact = call.contactId ? await ctx.db.get(call.contactId) : null;
+        return { ...call, contact };
+    },
+});
+
+export const getMyActiveCall = query({
+    args: {
+        organizationId: v.id("organizations"),
+    },
+    handler: async (ctx, args) => {
+        const userId = await getAuthUserId(ctx);
+        if (!userId) return null;
+
+        // Find the call this agent is handling
+        for (const status of ["PRE_ACCEPTED", "CONNECTED"] as const) {
+            const call = await ctx.db
+                .query("calls")
+                .withIndex("by_org_status", (q) =>
+                    q.eq("organizationId", args.organizationId).eq("status", status)
+                )
+                .first();
+
+            if (call && call.agentId === userId) {
+                const contact = call.contactId ? await ctx.db.get(call.contactId) : null;
+                return { ...call, contact };
+            }
+        }
+
+        return null;
+    },
+});
+
+export const getMyOutboundCall = query({
+    args: {
+        organizationId: v.id("organizations"),
+    },
+    handler: async (ctx, args) => {
+        const userId = await getAuthUserId(ctx);
+        if (!userId) return null;
+
+        // Check for outbound calls in progress states
+        for (const status of ["REQUESTING_PERMISSION", "PERMISSION_GRANTED", "RINGING"] as const) {
+            const call = await ctx.db
+                .query("calls")
+                .withIndex("by_org_status", (q) =>
+                    q.eq("organizationId", args.organizationId).eq("status", status)
+                )
+                .first();
+
+            if (call && call.agentId === userId && call.direction === "OUTBOUND") {
+                const contact = call.contactId ? await ctx.db.get(call.contactId) : null;
+                return { ...call, contact };
+            }
+        }
+
+        return null;
+    },
+});
+
+/**
+ * Returns status + terminationReason for a specific call owned by the agent.
+ * Used by the UI to detect async failures (CPR rejected, 24h window, etc.)
+ * after the call has moved to a terminal state.
+ */
+export const getCallStatusForAgent = query({
+    args: {
+        callId: v.id("calls"),
+    },
+    handler: async (ctx, args) => {
+        const userId = await getAuthUserId(ctx);
+        if (!userId) return null;
+
+        const call = await ctx.db.get(args.callId);
+        if (!call) return null;
+        if (call.agentId !== userId) return null;
+
+        return {
+            _id: call._id,
+            status: call.status,
+            terminationReason: call.terminationReason,
+            direction: call.direction,
+        };
+    },
+});
+
+export const getCallHistory = query({
+    args: {
+        conversationId: v.id("conversations"),
+    },
+    handler: async (ctx, args) => {
+        return await ctx.db
+            .query("calls")
+            .withIndex("by_conversation", (q) => q.eq("conversationId", args.conversationId))
+            .order("desc")
+            .take(20);
+    },
+});
+
+/**
+ * Returns the set of channels in the current organization that have had a
+ * FAILED outbound call within the freshness window whose terminationReason
+ * indicates an expired Meta token (code 190 / OAuthException / etc.).
+ *
+ * Used by the settings page to render a "Token expire" indicator on the
+ * affected channel, since Meta's read-only health probe (`getChannelStatus`)
+ * can still return OK while calling scopes are missing.
+ */
+export const getChannelsWithTokenError = query({
+    args: {
+        organizationId: v.id("organizations"),
+        windowMs: v.optional(v.number()),
+    },
+    handler: async (ctx, args) => {
+        const userId = await getAuthUserId(ctx);
+        if (!userId) return [];
+
+        const window = args.windowMs ?? 24 * 60 * 60 * 1000;
+        const since = Date.now() - window;
+
+        // Fetch FAILED calls for the org within the window; take enough rows
+        // to cover bursty failures without unbounded scanning.
+        const failed = await ctx.db
+            .query("calls")
+            .withIndex("by_org_status", (q) =>
+                q.eq("organizationId", args.organizationId).eq("status", "FAILED")
+            )
+            .order("desc")
+            .take(100);
+
+        const byChannel = new Map<
+            string,
+            { channelId: Id<"whatsappChannels">; lastErrorAt: number; reason: string }
+        >();
+
+        for (const call of failed) {
+            if (!call.whatsappChannelId) continue;
+            if (call.updatedAt < since) continue;
+
+            const raw = (call.terminationReason ?? "").toLowerCase();
+            const looksLikeToken =
+                raw.includes('"code":190') ||
+                raw.includes("(#190)") ||
+                raw.includes("oauthexception") ||
+                raw.includes("access token has expired") ||
+                raw.includes("session has been invalidated") ||
+                raw.includes("authentication error");
+            if (!looksLikeToken) continue;
+
+            const key = call.whatsappChannelId as unknown as string;
+            const existing = byChannel.get(key);
+            if (!existing || existing.lastErrorAt < call.updatedAt) {
+                byChannel.set(key, {
+                    channelId: call.whatsappChannelId,
+                    lastErrorAt: call.updatedAt,
+                    reason: call.terminationReason ?? "",
+                });
+            }
+        }
+
+        return Array.from(byChannel.values());
+    },
+});
+
+// ============================================
+// MUTATIONS (agent actions from the browser)
+// ============================================
+
+// --- OUTBOUND CALLS ---
+
+export const requestOutboundCall = mutation({
+    args: {
+        conversationId: v.id("conversations"),
+    },
+    handler: async (ctx, args) => {
+        const userId = await getAuthUserId(ctx);
+        if (!userId) throw new Error("Not authenticated");
+
+        const conversation = await ctx.db.get(args.conversationId);
+        if (!conversation) throw new Error("Conversation not found");
+
+        const contact = conversation.contactId
+            ? await ctx.db.get(conversation.contactId)
+            : null;
+        if (!contact?.phone) throw new Error("Contact has no phone number");
+
+        // Check for existing active calls
+        const existingCalls = await ctx.db
+            .query("calls")
+            .withIndex("by_conversation", (q) => q.eq("conversationId", args.conversationId))
+            .filter((q) =>
+                q.or(
+                    q.eq(q.field("status"), "REQUESTING_PERMISSION"),
+                    q.eq(q.field("status"), "PERMISSION_GRANTED"),
+                    q.eq(q.field("status"), "RINGING"),
+                    q.eq(q.field("status"), "PRE_ACCEPTED"),
+                    q.eq(q.field("status"), "CONNECTED"),
+                )
+            )
+            .collect();
+
+        const now = Date.now();
+        const PERMISSION_EXPIRY = 72 * 60 * 60_000; // 72h - Meta allows calling within 72h of permission
+        const CPR_WAIT_WINDOW = 24 * 60 * 60_000; // 24h - user may respond to CPR within a day
+
+        for (const call of existingCalls) {
+            // If permission already granted and still valid (within 72h) → reuse this call
+            if (call.status === "PERMISSION_GRANTED") {
+                if (now - call.startedAt < PERMISSION_EXPIRY) {
+                    // Reassign to current agent if needed
+                    if (call.agentId !== userId) {
+                        await ctx.db.patch(call._id, { agentId: userId, updatedAt: now });
+                    }
+                    return { callId: call._id, permissionAlreadyGranted: true };
+                }
+                // Expired permission → clean up
+                await ctx.db.patch(call._id, {
+                    status: "FAILED" as const,
+                    terminationReason: "permission_expired",
+                    endedAt: now,
+                    updatedAt: now,
+                });
+                continue;
+            }
+
+            // REQUESTING_PERMISSION: only clean up after 24h (user may respond late)
+            if (call.status === "REQUESTING_PERMISSION" && now - call.startedAt > CPR_WAIT_WINDOW) {
+                await ctx.db.patch(call._id, {
+                    status: "FAILED" as const,
+                    terminationReason: "cpr_expired",
+                    endedAt: now,
+                    updatedAt: now,
+                });
+                continue;
+            }
+
+            // Active call (RINGING, PRE_ACCEPTED, CONNECTED, or recent REQUESTING_PERMISSION) → block
+            throw new Error("An active call already exists for this conversation");
+        }
+
+        // No existing usable call → create new CPR request
+        const callId = await ctx.db.insert("calls", {
+            organizationId: conversation.organizationId,
+            conversationId: args.conversationId,
+            contactId: conversation.contactId,
+            whatsappChannelId: conversation.whatsappChannelId,
+            externalCallId: `outbound_${now}`,
+            direction: "OUTBOUND" as const,
+            fromPhone: "",
+            toPhone: contact.phone,
+            agentId: userId,
+            status: "REQUESTING_PERMISSION" as const,
+            startedAt: now,
+            createdAt: now,
+            updatedAt: now,
+        });
+
+        // Schedule CPR send
+        await ctx.scheduler.runAfter(0, internal.call_actions.sendCallPermissionRequest, {
+            callId,
+            organizationId: conversation.organizationId,
+            contactPhone: contact.phone,
+        });
+
+        return { callId, permissionAlreadyGranted: false };
+    },
+});
+
+export const startOutboundCall = mutation({
+    args: {
+        callId: v.id("calls"),
+        sdpOffer: v.string(),
+    },
+    handler: async (ctx, args) => {
+        const userId = await getAuthUserId(ctx);
+        if (!userId) throw new Error("Not authenticated");
+
+        const call = await ctx.db.get(args.callId);
+        if (!call) throw new Error("Call not found");
+
+        if (call.status !== "PERMISSION_GRANTED") {
+            throw new Error(`Cannot start call: status is ${call.status}, expected PERMISSION_GRANTED`);
+        }
+
+        const now = Date.now();
+        await ctx.db.patch(args.callId, {
+            sdpOffer: args.sdpOffer,
+            status: "RINGING" as const,
+            updatedAt: now,
+        });
+
+        // Schedule Meta API call
+        await ctx.scheduler.runAfter(0, internal.call_actions.sendOutboundCallOffer, {
+            callId: args.callId,
+        });
+
+        return { success: true };
+    },
+});
+
+// --- INBOUND CALLS ---
+
+export const acceptCall = mutation({
+    args: {
+        callId: v.id("calls"),
+        sdpAnswer: v.string(),
+    },
+    handler: async (ctx, args) => {
+        const userId = await getAuthUserId(ctx);
+        if (!userId) throw new Error("Not authenticated");
+
+        const call = await ctx.db.get(args.callId);
+        if (!call) throw new Error("Call not found");
+
+        // Optimistic concurrency: only accept if still ringing
+        if (call.status !== "RINGING") {
+            throw new Error(`Call is no longer ringing (status: ${call.status})`);
+        }
+
+        const now = Date.now();
+        await ctx.db.patch(args.callId, {
+            status: "PRE_ACCEPTED" as const,
+            agentId: userId,
+            sdpAnswer: args.sdpAnswer,
+            answeredAt: now,
+            updatedAt: now,
+        });
+
+        // Schedule the Meta API call to send pre_accept
+        await ctx.scheduler.runAfter(0, internal.call_actions.sendPreAccept, {
+            callId: args.callId,
+        });
+
+        return { success: true };
+    },
+});
+
+export const confirmConnected = mutation({
+    args: {
+        callId: v.id("calls"),
+    },
+    handler: async (ctx, args) => {
+        const call = await ctx.db.get(args.callId);
+        if (!call) throw new Error("Call not found");
+
+        if (call.status !== "PRE_ACCEPTED") {
+            console.log(`[CALLS] confirmConnected: call ${args.callId} is ${call.status}, not PRE_ACCEPTED`);
+            return;
+        }
+
+        await ctx.db.patch(args.callId, {
+            status: "CONNECTED" as const,
+            updatedAt: Date.now(),
+        });
+
+        // Send accept to Meta
+        await ctx.scheduler.runAfter(0, internal.call_actions.sendAccept, {
+            callId: args.callId,
+        });
+    },
+});
+
+export const rejectCall = mutation({
+    args: {
+        callId: v.id("calls"),
+    },
+    handler: async (ctx, args) => {
+        const userId = await getAuthUserId(ctx);
+        if (!userId) throw new Error("Not authenticated");
+
+        const call = await ctx.db.get(args.callId);
+        if (!call) throw new Error("Call not found");
+
+        if (call.status !== "RINGING") {
+            throw new Error(`Call is no longer ringing (status: ${call.status})`);
+        }
+
+        const now = Date.now();
+        await ctx.db.patch(args.callId, {
+            status: "REJECTED" as const,
+            endedAt: now,
+            updatedAt: now,
+        });
+
+        // Send reject to Meta
+        await ctx.scheduler.runAfter(0, internal.call_actions.sendReject, {
+            callId: args.callId,
+        });
+
+        // Insert system message
+        if (call.conversationId) {
+            await ctx.db.insert("messages", {
+                organizationId: call.organizationId,
+                conversationId: call.conversationId,
+                contactId: call.contactId,
+                type: "SYSTEM",
+                content: "Appel rejete",
+                direction: "INBOUND",
+                status: "DELIVERED",
+                createdAt: now,
+                updatedAt: now,
+            });
+
+            await ctx.db.patch(call.conversationId, {
+                lastMessageAt: now,
+                preview: "Appel rejete",
+                updatedAt: now,
+            });
+        }
+    },
+});
+
+export const terminateCall = mutation({
+    args: {
+        callId: v.id("calls"),
+    },
+    handler: async (ctx, args) => {
+        const call = await ctx.db.get(args.callId);
+        if (!call) throw new Error("Call not found");
+
+        if (call.status === "TERMINATED" || call.status === "REJECTED" || call.status === "MISSED") {
+            return; // Already ended
+        }
+
+        const now = Date.now();
+        const durationSeconds = call.answeredAt
+            ? Math.round((now - call.answeredAt) / 1000)
+            : undefined;
+
+        await ctx.db.patch(args.callId, {
+            status: "TERMINATED" as const,
+            endedAt: now,
+            durationSeconds,
+            terminationReason: "agent_hangup",
+            updatedAt: now,
+        });
+
+        // Send terminate to Meta
+        await ctx.scheduler.runAfter(0, internal.call_actions.sendTerminate, {
+            callId: args.callId,
+        });
+
+        // Insert system message
+        if (call.conversationId) {
+            const durationStr = durationSeconds
+                ? `${Math.floor(durationSeconds / 60)}:${String(durationSeconds % 60).padStart(2, "0")}`
+                : "0:00";
+
+            const content = `Appel audio - ${durationStr}`;
+
+            await ctx.db.insert("messages", {
+                organizationId: call.organizationId,
+                conversationId: call.conversationId,
+                contactId: call.contactId,
+                type: "SYSTEM",
+                content,
+                direction: "INBOUND",
+                status: "DELIVERED",
+                createdAt: now,
+                updatedAt: now,
+            });
+
+            await ctx.db.patch(call.conversationId, {
+                lastMessageAt: now,
+                preview: content,
+                updatedAt: now,
+            });
+        }
+    },
+});
+
+// ============================================
+// INTERNAL MUTATIONS (called from call_actions.ts)
+// ============================================
+
+export const updateExternalCallId = internalMutation({
+    args: {
+        callId: v.id("calls"),
+        externalCallId: v.string(),
+    },
+    handler: async (ctx, args) => {
+        await ctx.db.patch(args.callId, {
+            externalCallId: args.externalCallId,
+            updatedAt: Date.now(),
+        });
+    },
+});
+
+// ============================================
+// CRON: Expire missed calls
+// ============================================
+
+export const expireMissedCalls = internalMutation({
+    args: {},
+    handler: async (ctx) => {
+        const cutoff = Date.now() - 60_000; // 60 seconds timeout
+
+        // Get all organizations that have ringing calls
+        const ringingCalls = await ctx.db
+            .query("calls")
+            .filter((q) =>
+                q.and(
+                    q.eq(q.field("status"), "RINGING"),
+                    q.lt(q.field("startedAt"), cutoff)
+                )
+            )
+            .collect();
+
+        for (const call of ringingCalls) {
+            const now = Date.now();
+            await ctx.db.patch(call._id, {
+                status: "MISSED" as const,
+                endedAt: now,
+                updatedAt: now,
+            });
+
+            // Send terminate to Meta
+            await ctx.scheduler.runAfter(0, internal.call_actions.sendTerminate, {
+                callId: call._id,
+            });
+
+            // Insert system message
+            if (call.conversationId) {
+                await ctx.db.insert("messages", {
+                    organizationId: call.organizationId,
+                    conversationId: call.conversationId,
+                    contactId: call.contactId,
+                    type: "SYSTEM",
+                    content: "Appel manque",
+                    direction: "INBOUND",
+                    status: "DELIVERED",
+                    createdAt: now,
+                    updatedAt: now,
+                });
+
+                await ctx.db.patch(call.conversationId, {
+                    lastMessageAt: now,
+                    preview: "Appel manque",
+                    updatedAt: now,
+                });
+            }
+
+            console.log(`[CALLS] Call ${call.externalCallId} expired -> MISSED`);
+        }
+    },
+});

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -39,4 +39,7 @@ crons.daily(
     internal.crm.contactLinks.purgeStaleLinks,
 );
 
+// Expire ringing calls that were never answered (60s timeout) -> MISSED
+crons.interval("expire-missed-calls", { minutes: 1 }, internal.calls.expireMissedCalls);
+
 export default crons;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -128,6 +128,8 @@ http.route({
                 messageCount: value?.messages?.length ?? 0,
                 hasStatuses: !!value?.statuses,
                 statusCount: value?.statuses?.length ?? 0,
+                hasCalls: !!value?.calls,
+                callCount: value?.calls?.length ?? 0,
             }));
 
             if (!value) {
@@ -149,6 +151,41 @@ http.route({
                         text: message.text?.body?.slice(0, 100),
                         hasContext: !!message.context,
                     }));
+
+                    // Intercept interactive call_permission_reply messages (CPR acceptance)
+                    // These arrive as standard messages with type="interactive".
+                    const interactiveType = message?.interactive?.type;
+                    if (
+                        message.type === "interactive" &&
+                        (interactiveType === "call_permission_reply" ||
+                            interactiveType === "call_permission_request_reply")
+                    ) {
+                        const reply = message.interactive?.call_permission_reply
+                            ?? message.interactive?.call_permission_request_reply;
+                        const response = reply?.response;
+
+                        console.log("[Webhook] ☎️ Call permission reply", JSON.stringify({
+                            from: message.from,
+                            response,
+                            phoneNumberId: value.metadata?.phone_number_id,
+                        }));
+
+                        if (response === "accept" || response === "accepted") {
+                            try {
+                                await ctx.runMutation(internal.calls.handleCallWebhook, {
+                                    callId: message.id ?? `cpr_reply_${Date.now()}`,
+                                    from: message.from,
+                                    to: value.metadata?.display_phone_number ?? "",
+                                    event: "permission_request_accepted",
+                                    phoneNumberId: value.metadata?.phone_number_id,
+                                });
+                            } catch (cprError) {
+                                console.error("[Webhook] ❌ CPR reply error", String(cprError));
+                            }
+                        }
+                        // Do not also treat this as a regular message.
+                        continue;
+                    }
 
                     try {
                         await ctx.runMutation(internal.webhook.handleIncomingMessage, {
@@ -189,6 +226,39 @@ http.route({
                         console.error("[Webhook] ❌ Status error", JSON.stringify({
                             waMessageId: status.id,
                             error: String(statusError),
+                        }));
+                    }
+                }
+            }
+
+            // Case C: WhatsApp Calling events
+            if (value.calls) {
+                for (const call of value.calls) {
+                    console.log("[Webhook] ☎️ Call", JSON.stringify({
+                        callId: call.id,
+                        from: call.from,
+                        to: call.to,
+                        event: call.event,
+                        direction: call.direction,
+                        sdpType: call.session?.sdp_type,
+                        phoneNumberId: value.metadata?.phone_number_id,
+                    }));
+
+                    try {
+                        await ctx.runMutation(internal.calls.handleCallWebhook, {
+                            callId: call.id,
+                            from: call.from,
+                            to: call.to ?? value.metadata?.display_phone_number ?? "",
+                            event: call.event,
+                            direction: call.direction,
+                            sdp: call.session?.sdp,
+                            sdpType: call.session?.sdp_type,
+                            phoneNumberId: value.metadata?.phone_number_id,
+                        });
+                    } catch (callError) {
+                        console.error("[Webhook] ❌ Call webhook error", JSON.stringify({
+                            callId: call.id,
+                            error: String(callError),
                         }));
                     }
                 }

--- a/convex/lib/permissions.ts
+++ b/convex/lib/permissions.ts
@@ -28,7 +28,8 @@ export type Permission =
     | "teams:create" | "teams:update" | "teams:delete" | "teams:manage_members"
     | "channels:create" | "channels:update" | "channels:delete" | "channels:assign_team"
     | "broadcasts:create" | "broadcasts:send" | "broadcasts:override_channel"
-    | "integrations:read" | "integrations:manage";
+    | "integrations:read" | "integrations:manage"
+    | "calls:answer" | "calls:initiate" | "calls:view_history";
 
 const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
     OWNER: [
@@ -44,6 +45,7 @@ const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
         "channels:create", "channels:update", "channels:delete", "channels:assign_team",
         "broadcasts:create", "broadcasts:send", "broadcasts:override_channel",
         "integrations:read", "integrations:manage",
+        "calls:answer", "calls:initiate", "calls:view_history",
     ],
     ADMIN: [
         "org:read", "org:update",
@@ -58,6 +60,7 @@ const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
         "channels:create", "channels:update", "channels:assign_team",
         "broadcasts:create", "broadcasts:send",
         "integrations:read", "integrations:manage",
+        "calls:answer", "calls:initiate", "calls:view_history",
     ],
     AGENT: [
         "org:read",
@@ -69,6 +72,7 @@ const ROLE_PERMISSIONS: Record<Role, Permission[]> = {
         "flows:read",
         "settings:read",
         "integrations:read",
+        "calls:answer", "calls:initiate", "calls:view_history",
     ],
 };
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -1865,5 +1865,61 @@ export default defineSchema({
     })
         .index("by_connection_period", ["connectionId", "periodStart"])
         .index("by_org_period", ["organizationId", "periodStart"]),
+
+    // ============================================
+    // WhatsApp Calls
+    // ============================================
+    calls: defineTable({
+        organizationId: v.id("organizations"),
+        conversationId: v.optional(v.id("conversations")),
+        contactId: v.optional(v.id("contacts")),
+        whatsappChannelId: v.optional(v.id("whatsappChannels")),
+
+        // Meta's external call identifier (WhatsApp Cloud API)
+        externalCallId: v.string(),
+
+        direction: v.union(
+            v.literal("INBOUND"),
+            v.literal("OUTBOUND"),
+        ),
+
+        fromPhone: v.string(),
+        toPhone: v.string(),
+
+        // Agent handling the call (null until accepted)
+        agentId: v.optional(v.id("users")),
+
+        // WebRTC signaling
+        sdpOffer: v.optional(v.string()),
+        sdpAnswer: v.optional(v.string()),
+
+        status: v.union(
+            v.literal("RINGING"),
+            v.literal("PRE_ACCEPTED"),
+            v.literal("CONNECTED"),
+            v.literal("TERMINATED"),
+            v.literal("REJECTED"),
+            v.literal("MISSED"),
+            v.literal("FAILED"),
+            v.literal("REQUESTING_PERMISSION"),
+            v.literal("PERMISSION_GRANTED"),
+        ),
+
+        terminationReason: v.optional(v.string()),
+
+        startedAt: v.number(),
+        answeredAt: v.optional(v.number()),
+        endedAt: v.optional(v.number()),
+        durationSeconds: v.optional(v.number()),
+
+        createdAt: v.number(),
+        updatedAt: v.number(),
+    })
+        .index("by_organization", ["organizationId"])
+        .index("by_external_call_id", ["externalCallId"])
+        .index("by_org_status", ["organizationId", "status"])
+        .index("by_conversation", ["conversationId"])
+        .index("by_agent", ["agentId"])
+        .index("by_channel_status", ["whatsappChannelId", "status"]),
 });
 

--- a/convex/utils.ts
+++ b/convex/utils.ts
@@ -114,3 +114,64 @@ export const updateMessageStatus = internalMutation({
         });
     },
 });
+
+// ============================================
+// CALLS: internal helpers used by call_actions.ts
+// ============================================
+
+export const getCall = internalQuery({
+    args: { id: v.id("calls") },
+    handler: async (ctx, args) => {
+        return await ctx.db.get(args.id);
+    },
+});
+
+export const getWhatsAppChannel = internalQuery({
+    args: { id: v.id("whatsappChannels") },
+    handler: async (ctx, args) => {
+        return await ctx.db.get(args.id);
+    },
+});
+
+export const getWaba = internalQuery({
+    args: { id: v.id("wabas") },
+    handler: async (ctx, args) => {
+        return await ctx.db.get(args.id);
+    },
+});
+
+export const updateCallStatus = internalMutation({
+    args: {
+        callId: v.id("calls"),
+        status: v.union(
+            v.literal("RINGING"),
+            v.literal("PRE_ACCEPTED"),
+            v.literal("CONNECTED"),
+            v.literal("TERMINATED"),
+            v.literal("REJECTED"),
+            v.literal("MISSED"),
+            v.literal("FAILED"),
+            v.literal("REQUESTING_PERMISSION"),
+            v.literal("PERMISSION_GRANTED"),
+        ),
+        terminationReason: v.optional(v.string()),
+    },
+    handler: async (ctx, args) => {
+        const patch: Record<string, unknown> = {
+            status: args.status,
+            updatedAt: Date.now(),
+        };
+        if (args.terminationReason !== undefined) {
+            patch.terminationReason = args.terminationReason;
+        }
+        if (
+            args.status === "FAILED" ||
+            args.status === "TERMINATED" ||
+            args.status === "REJECTED" ||
+            args.status === "MISSED"
+        ) {
+            patch.endedAt = Date.now();
+        }
+        await ctx.db.patch(args.callId, patch);
+    },
+});

--- a/e2e/calls.spec.ts
+++ b/e2e/calls.spec.ts
@@ -1,0 +1,183 @@
+import { test, expect, Page } from '@playwright/test';
+
+// Tests for the outbound WhatsApp Business call flow.
+//
+// Regression target: clicking the call button triggered `getUserMedia` twice —
+// once in the click handler and once in an effect after PERMISSION_GRANTED.
+// The second call ran outside a user gesture and failed with NotAllowedError
+// on http:// origins. The fix pre-acquires the stream at click time, stores
+// it in the Zustand call-store, and `initiateCall` reuses it. These tests
+// lock that behaviour in.
+
+// Port is conductor-workspace dependent (main runs on :3000, worktrees may use
+// :1000, :2000, etc.). Override via E2E_PORT when running this spec locally.
+const PORT = process.env.E2E_PORT ?? '1000';
+const SCHEME = process.env.E2E_SCHEME ?? 'https';
+const BASE_URL = `${SCHEME}://be-in-digital.localhost:${PORT}`;
+const CONVERSATIONS_URL = `${BASE_URL}/dashboard/conversations`;
+
+// Inject a controllable mock of navigator.mediaDevices.getUserMedia and
+// expose a window counter so tests can assert how many times it was invoked.
+// `mode` controls whether it resolves or rejects.
+async function installMicMock(page: Page, mode: 'grant' | 'deny') {
+    await page.addInitScript((m: 'grant' | 'deny') => {
+        const w = window as unknown as {
+            __micCalls: number;
+            __micMode: 'grant' | 'deny';
+            __micStopCalls: number;
+        };
+        w.__micCalls = 0;
+        w.__micMode = m;
+        w.__micStopCalls = 0;
+
+        const fakeTrack = () => ({
+            kind: 'audio',
+            enabled: true,
+            readyState: 'live',
+            stop() {
+                w.__micStopCalls += 1;
+            },
+            addEventListener() {},
+            removeEventListener() {},
+        });
+
+        const fakeStream = () => {
+            const tracks = [fakeTrack()];
+            return {
+                active: true,
+                id: 'mock-stream',
+                getTracks: () => tracks,
+                getAudioTracks: () => tracks,
+                getVideoTracks: () => [],
+                addEventListener() {},
+                removeEventListener() {},
+            };
+        };
+
+        const nav = navigator as unknown as { mediaDevices?: MediaDevices };
+        if (!nav.mediaDevices) {
+            nav.mediaDevices = {} as MediaDevices;
+        }
+        Object.defineProperty(nav.mediaDevices, 'getUserMedia', {
+            configurable: true,
+            value: async () => {
+                w.__micCalls += 1;
+                if (w.__micMode === 'deny') {
+                    throw new DOMException('Permission denied', 'NotAllowedError');
+                }
+                return fakeStream() as unknown as MediaStream;
+            },
+        });
+    }, mode);
+}
+
+// Select the call button inside the conversation header. It is a ghost icon
+// button wrapping the lucide Phone/PhoneCall/AlertCircle icon. We use the
+// svg class as a stable hook.
+function callButton(page: Page) {
+    return page.locator('button').filter({
+        has: page.locator('svg.lucide-phone, svg.lucide-phone-call, svg.lucide-alert-circle'),
+    }).first();
+}
+
+async function openFirstConversation(page: Page) {
+    await page.goto(CONVERSATIONS_URL);
+    await page.waitForLoadState('networkidle');
+
+    // Conversation list items — tolerate absence in a clean seed.
+    const firstItem = page.locator('[data-conversation-id], [role="listitem"], a[href*="/dashboard/conversations/"]').first();
+    if (await firstItem.count() === 0) {
+        return false;
+    }
+    await firstItem.click();
+    await page.waitForLoadState('networkidle');
+    return true;
+}
+
+test.describe('Outbound call flow', () => {
+    test('getUserMedia is called exactly once on Appeler click', async ({ page, context }) => {
+        await context.grantPermissions(['microphone'], { origin: BASE_URL });
+        await installMicMock(page, 'grant');
+
+        const opened = await openFirstConversation(page);
+        test.skip(!opened, 'No seeded conversation available');
+
+        const btn = callButton(page);
+        await expect(btn).toBeVisible({ timeout: 5000 });
+        await btn.click();
+
+        // Allow the click handler to finish before asserting.
+        await page.waitForTimeout(500);
+
+        const micCalls = await page.evaluate(() => (window as unknown as { __micCalls: number }).__micCalls);
+        expect(micCalls).toBe(1);
+
+        // The click handler should have transitioned the UI to "requesting_permission"
+        // or rendered the error bar. Either way, it should not be in idle anymore.
+        const barVisible = await page.getByText(/Demande de permission envoyee|Autorisez l'acces au microphone/i).isVisible().catch(() => false);
+        expect(barVisible).toBeTruthy();
+    });
+
+    test('NotAllowedError surfaces the mic permission button', async ({ page, context }) => {
+        await context.grantPermissions(['microphone'], { origin: BASE_URL });
+        await installMicMock(page, 'deny');
+
+        const opened = await openFirstConversation(page);
+        test.skip(!opened, 'No seeded conversation available');
+
+        const btn = callButton(page);
+        await expect(btn).toBeVisible({ timeout: 5000 });
+        await btn.click();
+
+        // Error bar with the mic message appears.
+        await expect(page.getByText(/Autorisez l'acces au microphone/i)).toBeVisible({ timeout: 3000 });
+
+        // The contextual fix-it button is rendered.
+        await expect(page.getByRole('button', { name: /Autoriser le microphone/i })).toBeVisible();
+    });
+
+    test('retry via "Autoriser le microphone" re-triggers getUserMedia', async ({ page, context }) => {
+        await context.grantPermissions(['microphone'], { origin: BASE_URL });
+        await installMicMock(page, 'deny');
+
+        const opened = await openFirstConversation(page);
+        test.skip(!opened, 'No seeded conversation available');
+
+        const btn = callButton(page);
+        await expect(btn).toBeVisible({ timeout: 5000 });
+        await btn.click();
+
+        await expect(page.getByText(/Autorisez l'acces au microphone/i)).toBeVisible({ timeout: 3000 });
+
+        const micCallsBefore = await page.evaluate(() => (window as unknown as { __micCalls: number }).__micCalls);
+
+        // Flip the mock so the next getUserMedia resolves, then click the retry.
+        await page.evaluate(() => {
+            (window as unknown as { __micMode: 'grant' | 'deny' }).__micMode = 'grant';
+        });
+        await page.getByRole('button', { name: /Autoriser le microphone/i }).click();
+
+        await page.waitForTimeout(500);
+
+        const micCallsAfter = await page.evaluate(() => (window as unknown as { __micCalls: number }).__micCalls);
+        expect(micCallsAfter).toBeGreaterThan(micCallsBefore);
+
+        // Error bar should no longer show the mic message (either cleared or moved to a different pending state).
+        await expect(page.getByText(/Autorisez l'acces au microphone/i)).toBeHidden({ timeout: 3000 });
+    });
+});
+
+// End-to-end coverage of the token-expired (Meta code 190) error display
+// is exercised at the unit level in:
+//   - components/calls/call-error-messages.test.ts   (20 cases, incl. exact
+//     Meta 401 payload → reconnect-whatsapp action)
+//   - components/calls/call-error-action-button.test.tsx (UI rendering of the
+//     Reconnecter WhatsApp link → /dashboard/settings?tab=channels)
+//   - components/calls/fallback-reason.test.ts       (race-resolution: the
+//     provider's fallback timer prefers the tracked terminationReason over a
+//     generic error when a terminal status has already landed).
+//
+// A full Playwright reproduction would require either (a) seeded auth +
+// conversations + a real WABA with a revoked token, or (b) a test-only hook
+// into the Zustand store from page.evaluate(). Both add more friction than
+// value beyond the 227-strong unit/integration suite.

--- a/hooks/use-webrtc-call.ts
+++ b/hooks/use-webrtc-call.ts
@@ -1,0 +1,288 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+import { useMutation } from 'convex/react';
+import { api } from '@/convex/_generated/api';
+import { useCallStore } from '@/lib/stores/call-store';
+import type { Id } from '@/convex/_generated/dataModel';
+
+/**
+ * Hook managing the browser-side RTCPeerConnection for WhatsApp Business calls.
+ *
+ * Flow (inbound):
+ * 1. Meta sends SDP offer via webhook -> stored in Convex `calls` table
+ * 2. Browser picks it up via useQuery subscription (in CallNotificationProvider)
+ * 3. Agent clicks "Accept" -> this hook creates RTCPeerConnection
+ * 4. Sets remote description (Meta's offer), creates answer
+ * 5. Sends SDP answer to Convex -> Convex action -> Meta Graph API (pre_accept)
+ * 6. WebRTC ICE negotiation completes -> confirmConnected -> Meta (accept)
+ * 7. Audio flows: Meta servers <-> Agent's browser
+ *
+ * Flow (outbound):
+ * 1. Agent clicks "Call" -> requestOutboundCall -> CPR sent to contact
+ * 2. Contact accepts permission -> status becomes PERMISSION_GRANTED (reactive)
+ * 3. Agent clicks "Appeler maintenant" -> initiateCall creates RTCPeerConnection
+ * 4. Creates SDP offer -> startOutboundCall -> Meta API sends offer
+ * 5. Meta sends SDP answer via webhook -> stored in calls table (reactive)
+ * 6. Browser picks up SDP answer -> setRemoteDescription -> audio flows
+ */
+export function useWebRTCCall() {
+    const [isAudioReady, setIsAudioReady] = useState(false);
+    const peerConnectionRef = useRef<RTCPeerConnection | null>(null);
+    const localStreamRef = useRef<MediaStream | null>(null);
+    const remoteAudioRef = useRef<HTMLAudioElement | null>(null);
+
+    const { setCallState, toggleMute: storeToggleMute, isMuted, clearCall, setMicStream } = useCallStore();
+
+    const acceptCallMutation = useMutation(api.calls.acceptCall);
+    const confirmConnectedMutation = useMutation(api.calls.confirmConnected);
+    const terminateCallMutation = useMutation(api.calls.terminateCall);
+    const startOutboundCallMutation = useMutation(api.calls.startOutboundCall);
+
+    // ---- INBOUND: Answer an incoming call ----
+    const answerCall = useCallback(async (callId: Id<"calls">, sdpOffer: string) => {
+        try {
+            const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+            localStreamRef.current = stream;
+
+            const pc = new RTCPeerConnection({
+                iceServers: [
+                    { urls: 'stun:stun.l.google.com:19302' },
+                    { urls: 'stun:stun1.l.google.com:19302' },
+                ],
+            });
+            peerConnectionRef.current = pc;
+
+            stream.getTracks().forEach(track => pc.addTrack(track, stream));
+
+            pc.ontrack = (event) => {
+                if (remoteAudioRef.current && event.streams[0]) {
+                    remoteAudioRef.current.srcObject = event.streams[0];
+                    setIsAudioReady(true);
+                }
+            };
+
+            await pc.setRemoteDescription({ type: 'offer', sdp: sdpOffer });
+
+            const answer = await pc.createAnswer();
+            await pc.setLocalDescription(answer);
+
+            const sdpAnswer = await waitForIceGathering(pc);
+
+            await acceptCallMutation({ callId, sdpAnswer });
+
+            setCallState('connecting');
+
+            pc.oniceconnectionstatechange = () => {
+                const state = pc.iceConnectionState;
+                if (state === 'connected' || state === 'completed') {
+                    setCallState('connected');
+                    confirmConnectedMutation({ callId });
+                }
+                if (state === 'disconnected' || state === 'failed' || state === 'closed') {
+                    cleanup();
+                    setCallState('ended');
+                }
+            };
+
+            pc.onconnectionstatechange = () => {
+                if (pc.connectionState === 'failed' || pc.connectionState === 'closed') {
+                    cleanup();
+                    setCallState('ended');
+                }
+            };
+        } catch (error) {
+            console.error('[WebRTC] Failed to answer call:', error);
+            cleanup();
+            setCallState('ended');
+            throw error;
+        }
+    }, [acceptCallMutation, confirmConnectedMutation, setCallState]);
+
+    // ---- OUTBOUND: Initiate a call after permission granted ----
+    const initiateCall = useCallback(async (callId: Id<"calls">) => {
+        try {
+            setCallState('dialing');
+            console.log('[call-flow] initiateCall: state -> dialing, callId:', callId);
+
+            // Reuse the pre-acquired stream stored during the click handler.
+            // This avoids calling getUserMedia from inside a useEffect (non-user-gesture
+            // context) which would fail with NotAllowedError on non-HTTPS origins.
+            let stream: MediaStream;
+            const storedStream = useCallStore.getState().micStream;
+            if (storedStream && storedStream.active) {
+                console.log('[call-flow] initiateCall: reusing pre-acquired mic stream from store');
+                stream = storedStream;
+                // Clear the store reference so we own the stream exclusively.
+                setMicStream(null);
+            } else {
+                // Fallback: attempt getUserMedia (works on HTTPS or if already granted).
+                console.log('[call-flow] initiateCall: no stored stream, calling getUserMedia');
+                try {
+                    stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+                    console.log('[call-flow] initiateCall: getUserMedia succeeded');
+                } catch (micErr) {
+                    const e = micErr as DOMException;
+                    const permState = await navigator.permissions
+                        .query({ name: 'microphone' as PermissionName })
+                        .then((s) => s.state)
+                        .catch(() => 'unavailable');
+                    console.error('[call-flow] initiateCall: getUserMedia failed', {
+                        name: e.name,
+                        message: e.message,
+                        permissionState: permState,
+                    });
+                    throw micErr;
+                }
+            }
+            localStreamRef.current = stream;
+
+            const pc = new RTCPeerConnection({
+                iceServers: [
+                    { urls: 'stun:stun.l.google.com:19302' },
+                    { urls: 'stun:stun1.l.google.com:19302' },
+                ],
+            });
+            peerConnectionRef.current = pc;
+
+            stream.getTracks().forEach(track => pc.addTrack(track, stream));
+
+            pc.ontrack = (event) => {
+                if (remoteAudioRef.current && event.streams[0]) {
+                    remoteAudioRef.current.srcObject = event.streams[0];
+                    setIsAudioReady(true);
+                }
+            };
+
+            // Create offer
+            const offer = await pc.createOffer();
+            await pc.setLocalDescription(offer);
+
+            const sdpOffer = await waitForIceGathering(pc);
+
+            // Send to Convex -> Meta
+            await startOutboundCallMutation({ callId, sdpOffer });
+
+            // Monitor connection state
+            pc.oniceconnectionstatechange = () => {
+                const state = pc.iceConnectionState;
+                if (state === 'connected' || state === 'completed') {
+                    setCallState('connected');
+                    confirmConnectedMutation({ callId });
+                }
+                if (state === 'disconnected' || state === 'failed' || state === 'closed') {
+                    cleanup();
+                    // Don't override error state set by the provider
+                    const currentState = useCallStore.getState().callState;
+                    if (currentState !== 'error') {
+                        setCallState('ended');
+                    }
+                }
+            };
+
+            pc.onconnectionstatechange = () => {
+                if (pc.connectionState === 'failed' || pc.connectionState === 'closed') {
+                    cleanup();
+                    const currentState = useCallStore.getState().callState;
+                    if (currentState !== 'error') {
+                        setCallState('ended');
+                    }
+                }
+            };
+        } catch (error) {
+            console.error('[WebRTC] Failed to initiate outbound call:', error);
+            cleanup();
+            // Don't override error state set by the provider
+            const currentState = useCallStore.getState().callState;
+            if (currentState !== 'error') {
+                setCallState('ended');
+            }
+            throw error;
+        }
+    }, [startOutboundCallMutation, confirmConnectedMutation, setCallState]);
+
+    // ---- Apply remote SDP answer (for outbound calls) ----
+    const applyRemoteSdpAnswer = useCallback(async (sdpAnswer: string) => {
+        const pc = peerConnectionRef.current;
+        if (!pc) {
+            console.error('[WebRTC] No peer connection for remote SDP answer');
+            return;
+        }
+        try {
+            await pc.setRemoteDescription({ type: 'answer', sdp: sdpAnswer });
+            console.log('[WebRTC] Remote SDP answer applied');
+        } catch (error) {
+            console.error('[WebRTC] Failed to apply remote SDP answer:', error);
+        }
+    }, []);
+
+    const hangUp = useCallback(async (callId: Id<"calls">) => {
+        cleanup();
+        setCallState('ended');
+
+        try {
+            await terminateCallMutation({ callId });
+        } catch (error) {
+            console.error('[WebRTC] Failed to terminate call:', error);
+        }
+
+        setTimeout(() => clearCall(), 1500);
+    }, [terminateCallMutation, setCallState, clearCall]);
+
+    const toggleMute = useCallback(() => {
+        const stream = localStreamRef.current;
+        if (stream) {
+            stream.getAudioTracks().forEach(track => {
+                track.enabled = !track.enabled;
+            });
+        }
+        storeToggleMute();
+    }, [storeToggleMute]);
+
+    function cleanup() {
+        if (peerConnectionRef.current) {
+            peerConnectionRef.current.close();
+            peerConnectionRef.current = null;
+        }
+        if (localStreamRef.current) {
+            localStreamRef.current.getTracks().forEach(t => t.stop());
+            localStreamRef.current = null;
+        }
+        setIsAudioReady(false);
+    }
+
+    return {
+        answerCall,
+        initiateCall,
+        applyRemoteSdpAnswer,
+        hangUp,
+        toggleMute,
+        isMuted,
+        isAudioReady,
+        remoteAudioRef,
+    };
+}
+
+/**
+ * Waits for ICE gathering to complete and returns the final SDP.
+ * Meta expects a complete SDP (no trickle ICE).
+ */
+function waitForIceGathering(pc: RTCPeerConnection): Promise<string> {
+    return new Promise((resolve) => {
+        if (pc.iceGatheringState === 'complete') {
+            resolve(pc.localDescription!.sdp);
+            return;
+        }
+
+        const timeout = setTimeout(() => {
+            resolve(pc.localDescription!.sdp);
+        }, 3000);
+
+        pc.onicegatheringstatechange = () => {
+            if (pc.iceGatheringState === 'complete') {
+                clearTimeout(timeout);
+                resolve(pc.localDescription!.sdp);
+            }
+        };
+    });
+}

--- a/lib/stores/call-store.test.ts
+++ b/lib/stores/call-store.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { useCallStore } from '@/lib/stores/call-store';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Reset store to initial defaults between tests. */
+const initialState = {
+    activeCallId: null,
+    callState: 'idle' as const,
+    contactName: null,
+    contactPhone: null,
+    callDirection: 'INBOUND' as const,
+    callStartedAt: null,
+    isMuted: false,
+    conversationId: null,
+    errorMessage: null,
+    errorAction: null,
+    micStream: null,
+};
+
+beforeEach(() => {
+    useCallStore.setState(initialState);
+});
+
+// ---------------------------------------------------------------------------
+// clearCall
+// ---------------------------------------------------------------------------
+
+describe('clearCall()', () => {
+    it('resets all fields to their defaults and sets micStream to null', () => {
+        // Arrange — put the store in a non-default state
+        useCallStore.setState({
+            callState: 'connected',
+            contactName: 'Alice',
+            contactPhone: '+33600000000',
+            errorMessage: 'some error',
+            errorAction: { type: 'retry' },
+            isMuted: true,
+            callStartedAt: 123456789,
+        });
+
+        // Act
+        useCallStore.getState().clearCall();
+
+        // Assert
+        const state = useCallStore.getState();
+        expect(state.activeCallId).toBeNull();
+        expect(state.callState).toBe('idle');
+        expect(state.contactName).toBeNull();
+        expect(state.contactPhone).toBeNull();
+        expect(state.callStartedAt).toBeNull();
+        expect(state.isMuted).toBe(false);
+        expect(state.conversationId).toBeNull();
+        expect(state.errorMessage).toBeNull();
+        expect(state.errorAction).toBeNull();
+        expect(state.micStream).toBeNull();
+    });
+
+    it('calls .stop() on each track of micStream before clearing it', () => {
+        // Arrange — mock a MediaStream with two tracks
+        const stopA = vi.fn();
+        const stopB = vi.fn();
+        const mockStream = {
+            getTracks: () => [{ stop: stopA }, { stop: stopB }],
+        } as unknown as MediaStream;
+
+        useCallStore.setState({ micStream: mockStream });
+
+        // Act
+        useCallStore.getState().clearCall();
+
+        // Assert
+        expect(stopA).toHaveBeenCalledOnce();
+        expect(stopB).toHaveBeenCalledOnce();
+        expect(useCallStore.getState().micStream).toBeNull();
+    });
+
+    it('does not throw when micStream is null', () => {
+        // Ensure no micStream is set
+        useCallStore.setState({ micStream: null });
+
+        expect(() => useCallStore.getState().clearCall()).not.toThrow();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// setMicStream
+// ---------------------------------------------------------------------------
+
+describe('setMicStream()', () => {
+    it('stores the provided stream', () => {
+        const mockStream = {
+            getTracks: () => [],
+        } as unknown as MediaStream;
+
+        useCallStore.getState().setMicStream(mockStream);
+
+        expect(useCallStore.getState().micStream).toBe(mockStream);
+    });
+
+    it('sets micStream back to null when called with null', () => {
+        const mockStream = { getTracks: () => [] } as unknown as MediaStream;
+        useCallStore.setState({ micStream: mockStream });
+
+        useCallStore.getState().setMicStream(null);
+
+        expect(useCallStore.getState().micStream).toBeNull();
+    });
+
+    // Regression: MicPermissionButton called setMicStream BEFORE clearCall,
+    // so clearCall immediately stopped the tracks and nulled the ref we just
+    // set. initiateCall then fell back to a second getUserMedia outside the
+    // user gesture → NotAllowedError on http:// origins. Locking the ordering
+    // contract here: clearCall() → setMicStream(fresh) must preserve fresh.
+    it('clearCall() followed by setMicStream(fresh) keeps the fresh stream alive', () => {
+        const stopFresh = vi.fn();
+        const freshStream = {
+            getTracks: () => [{ stop: stopFresh }],
+        } as unknown as MediaStream;
+
+        const stopStale = vi.fn();
+        const staleStream = {
+            getTracks: () => [{ stop: stopStale }],
+        } as unknown as MediaStream;
+
+        useCallStore.setState({ micStream: staleStream });
+
+        useCallStore.getState().clearCall();
+        useCallStore.getState().setMicStream(freshStream);
+
+        expect(stopStale).toHaveBeenCalledOnce();
+        expect(stopFresh).not.toHaveBeenCalled();
+        expect(useCallStore.getState().micStream).toBe(freshStream);
+    });
+});
+
+// ---------------------------------------------------------------------------
+// setCallContext
+// ---------------------------------------------------------------------------
+
+describe('setCallContext()', () => {
+    it('writes contactName, contactPhone, conversationId and callDirection=OUTBOUND', () => {
+        const conversationId = 'conv123' as unknown as import('@/convex/_generated/dataModel').Id<'conversations'>;
+
+        useCallStore.getState().setCallContext(
+            { name: 'Bob', phone: '+33611223344' },
+            conversationId,
+        );
+
+        const state = useCallStore.getState();
+        expect(state.contactName).toBe('Bob');
+        expect(state.contactPhone).toBe('+33611223344');
+        expect(state.conversationId).toBe(conversationId);
+        expect(state.callDirection).toBe('OUTBOUND');
+    });
+
+    it('does not change callState', () => {
+        useCallStore.setState({ callState: 'connected' });
+        const conversationId = 'conv456' as unknown as import('@/convex/_generated/dataModel').Id<'conversations'>;
+
+        useCallStore.getState().setCallContext({ phone: '+33600000001' }, conversationId);
+
+        expect(useCallStore.getState().callState).toBe('connected');
+    });
+
+    it('sets contactName to null when name is omitted', () => {
+        const conversationId = 'conv789' as unknown as import('@/convex/_generated/dataModel').Id<'conversations'>;
+
+        useCallStore.getState().setCallContext({ phone: '+33600000002' }, conversationId);
+
+        expect(useCallStore.getState().contactName).toBeNull();
+    });
+});
+
+// ---------------------------------------------------------------------------
+// setError
+// ---------------------------------------------------------------------------
+
+describe('setError()', () => {
+    it('with a plain string sets errorMessage and errorAction to null', () => {
+        useCallStore.getState().setError('Simple error text');
+
+        const state = useCallStore.getState();
+        expect(state.callState).toBe('error');
+        expect(state.errorMessage).toBe('Simple error text');
+        expect(state.errorAction).toBeNull();
+    });
+
+    it('with a CallErrorMessage object preserves the action', () => {
+        useCallStore.getState().setError({
+            message: 'Mic not allowed',
+            action: { type: 'mic' },
+        });
+
+        const state = useCallStore.getState();
+        expect(state.callState).toBe('error');
+        expect(state.errorMessage).toBe('Mic not allowed');
+        expect(state.errorAction).toEqual({ type: 'mic' });
+    });
+
+    it('with a CallErrorMessage whose action is undefined stores null for errorAction', () => {
+        useCallStore.getState().setError({ message: 'No action needed' });
+
+        expect(useCallStore.getState().errorAction).toBeNull();
+    });
+
+    // Regression: setError() was NOT stopping micStream tracks, leaving the mic
+    // device in-use. A subsequent getUserMedia call (e.g. MicPermissionButton retry)
+    // would then fail with NotAllowedError: Permission denied even though Chrome
+    // had granted mic permission for the site.
+    it('stops and nulls a live micStream before entering error state', () => {
+        const stopA = vi.fn();
+        const stopB = vi.fn();
+        const mockStream = {
+            getTracks: () => [{ stop: stopA }, { stop: stopB }],
+        } as unknown as MediaStream;
+
+        useCallStore.setState({ micStream: mockStream, callState: 'requesting_permission' });
+
+        useCallStore.getState().setError('Something went wrong');
+
+        expect(stopA).toHaveBeenCalledOnce();
+        expect(stopB).toHaveBeenCalledOnce();
+        expect(useCallStore.getState().micStream).toBeNull();
+        expect(useCallStore.getState().callState).toBe('error');
+    });
+
+    it('does not throw when micStream is null at the time of error', () => {
+        useCallStore.setState({ micStream: null });
+
+        expect(() => useCallStore.getState().setError('Error with no stream')).not.toThrow();
+        expect(useCallStore.getState().callState).toBe('error');
+    });
+});

--- a/lib/stores/call-store.ts
+++ b/lib/stores/call-store.ts
@@ -1,0 +1,128 @@
+import { create } from 'zustand';
+import type { Id } from '@/convex/_generated/dataModel';
+import type { CallErrorAction, CallErrorMessage } from '@/components/calls/call-error-messages';
+
+export type CallState =
+    | 'idle'
+    | 'ringing'
+    | 'connecting'
+    | 'connected'
+    | 'ended'
+    | 'requesting_permission'
+    | 'permission_granted'
+    | 'dialing'
+    | 'error';
+
+interface CallStore {
+    activeCallId: Id<"calls"> | null;
+    callState: CallState;
+    contactName: string | null;
+    contactPhone: string | null;
+    callDirection: 'INBOUND' | 'OUTBOUND';
+    callStartedAt: number | null;
+    isMuted: boolean;
+    conversationId: Id<"conversations"> | null;
+    errorMessage: string | null;
+    errorAction: CallErrorAction | null;
+    /**
+     * Pre-acquired MediaStream kept alive from the click handler so that
+     * initiateCall (which runs in a useEffect, outside a user gesture) can
+     * reuse it without triggering a new getUserMedia prompt.
+     * Cleared on clearCall or after it is consumed by initiateCall.
+     */
+    micStream: MediaStream | null;
+
+    setIncomingCall: (callId: Id<"calls">, contact: { name?: string; phone: string }) => void;
+    setOutgoingCall: (callId: Id<"calls">, contact: { name?: string; phone: string }, conversationId: Id<"conversations">) => void;
+    setCallContext: (contact: { name?: string; phone: string }, conversationId: Id<"conversations">) => void;
+    setCallState: (state: CallState) => void;
+    setError: (error: string | CallErrorMessage) => void;
+    setMicStream: (stream: MediaStream | null) => void;
+    toggleMute: () => void;
+    clearCall: () => void;
+}
+
+export const useCallStore = create<CallStore>((set) => ({
+    activeCallId: null,
+    callState: 'idle',
+    contactName: null,
+    contactPhone: null,
+    callDirection: 'INBOUND',
+    callStartedAt: null,
+    isMuted: false,
+    conversationId: null,
+    errorMessage: null,
+    errorAction: null,
+    micStream: null,
+
+    setIncomingCall: (callId, contact) => set({
+        activeCallId: callId,
+        callState: 'ringing',
+        contactName: contact.name || null,
+        contactPhone: contact.phone,
+        callDirection: 'INBOUND',
+        callStartedAt: Date.now(),
+        errorMessage: null,
+        errorAction: null,
+    }),
+
+    setOutgoingCall: (callId, contact, conversationId) => set({
+        activeCallId: callId,
+        callState: 'requesting_permission',
+        contactName: contact.name || null,
+        contactPhone: contact.phone,
+        callDirection: 'OUTBOUND',
+        callStartedAt: Date.now(),
+        conversationId,
+        errorMessage: null,
+        errorAction: null,
+    }),
+
+    setCallContext: (contact, conversationId) => set({
+        contactName: contact.name || null,
+        contactPhone: contact.phone,
+        conversationId,
+        callDirection: 'OUTBOUND',
+    }),
+
+    setCallState: (state) => set({ callState: state, errorMessage: null, errorAction: null }),
+
+    setError: (error) => {
+        // Stop any live mic stream before entering error state so that the
+        // device is released and a subsequent getUserMedia (e.g. "Autoriser le
+        // microphone" retry) is not refused with NotAllowedError because the
+        // browser still sees the track as in-use by this tab.
+        set((s) => {
+            if (s.micStream) {
+                s.micStream.getTracks().forEach((t) => t.stop());
+            }
+            if (typeof error === 'string') {
+                return { callState: 'error', errorMessage: error, errorAction: null, micStream: null };
+            }
+            return { callState: 'error', errorMessage: error.message, errorAction: error.action ?? null, micStream: null };
+        });
+    },
+
+    setMicStream: (stream) => set({ micStream: stream }),
+
+    toggleMute: () => set((s) => ({ isMuted: !s.isMuted })),
+
+    clearCall: () => set((s) => {
+        // Stop and release any pre-acquired mic stream before clearing state.
+        if (s.micStream) {
+            s.micStream.getTracks().forEach((t) => t.stop());
+        }
+        return {
+            activeCallId: null,
+            callState: 'idle',
+            contactName: null,
+            contactPhone: null,
+            callStartedAt: null,
+            isMuted: false,
+            conversationId: null,
+            errorMessage: null,
+            errorAction: null,
+            micStream: null,
+        };
+    }),
+}));


### PR DESCRIPTION
## Summary

- Ajoute la fonctionnalite d'appels WhatsApp Business (inbound + outbound) avec Convex comme relais de signalisation et le navigateur de l'agent comme peer WebRTC.
- Expose un indicateur de token expire (Meta code 190) par canal en lisant l'historique des appels, contournant le probe de sante Meta qui reporte `OK` meme quand les scopes de calling sont casses.
- Corrige `FB.login() called before FB.init()` sur `/facebook-connect` en supprimant le `FB.init()` redondant.

## Details

- Schema: table `calls` + `callingEnabled` sur `whatsappChannels`, 6 indexes.
- Backend: `convex/calls.ts` (mutations/queries), `convex/call_actions.ts` (Meta Graph API), webhook parse `value.calls` + replies interactives CPR, cron expire-missed-calls.
- Frontend: hook `useWebRTCCall`, store Zustand, `IncomingCallDialog`, `ActiveCallBar`, `CallButton`, `CallNotificationProvider`, gestion NotAllowedError avec retry.
- Outbound: flow CPR (Call Permission Request) puis SDP offer/answer, acquisition du micro au click utilisateur pour eviter NotAllowedError hors gesture.
- Permissions: `calls:answer`, `calls:initiate`, `calls:view_history` (OWNER/ADMIN/AGENT).
- Tests: 245 unit tests verts + 3 E2E Playwright (skip gracieux si seed vide).