### PR TITLE
feat(billing): enforce plan limits with cascade on downgrade

### DIFF
--- a/components/settings/ChannelsSettings.tsx
+++ b/components/settings/ChannelsSettings.tsx
@@ -114,6 +114,9 @@ export function ChannelsSettings() {
 
     const activeChannels = channels.filter((c: any) => c.status !== 'disabled')
     const channelsWithTokenError = channels.filter((c: any) => tokenErrors[c._id])
+    const downgradedChannels = channels.filter(
+        (c: any) => c.status === 'disabled' && c.disabledReason === 'plan_downgrade',
+    )
     const maxChannels = currentPlan?.maxWhatsappChannels ?? 1
     const canAddMore = isUnlimited(maxChannels) || activeChannels.length < maxChannels
     const usagePercent = isUnlimited(maxChannels) ? 0 : Math.round((activeChannels.length / maxChannels) * 100)
@@ -269,6 +272,37 @@ export function ChannelsSettings() {
                         </div>
                     )}
                 </CardHeader>
+
+                {/* Plan downgrade banner */}
+                {downgradedChannels.length > 0 && (
+                    <div className="mx-6 mb-4 rounded-lg border border-amber-200 bg-amber-50 p-3">
+                        <div className="flex items-start gap-3">
+                            <div className="h-8 w-8 rounded-full bg-amber-100 flex items-center justify-center shrink-0 mt-0.5">
+                                <AlertTriangle className="h-4 w-4 text-amber-600" />
+                            </div>
+                            <div className="flex-1 min-w-0">
+                                <p className="text-sm font-medium text-amber-800">
+                                    {downgradedChannels.length === 1
+                                        ? `Le canal "${downgradedChannels[0].label}" a été désactivé après un changement de plan`
+                                        : `${downgradedChannels.length} canaux ont été désactivés après un changement de plan`}
+                                </p>
+                                <p className="text-xs text-amber-700 mt-0.5">
+                                    Votre plan actuel {currentPlan?.name ? `(${currentPlan.name})` : ''} autorise
+                                    {' '}{isUnlimited(maxChannels) ? '\u221E' : maxChannels} canal{maxChannels > 1 ? 'aux' : ''} actif{maxChannels > 1 ? 's' : ''}.
+                                    Passez à un plan supérieur pour les réactiver.
+                                </p>
+                            </div>
+                            <Button
+                                size="sm"
+                                className="h-8 text-xs gap-1.5 rounded-full cursor-pointer bg-amber-600 hover:bg-amber-700 text-white shrink-0"
+                                onClick={() => { window.location.href = '/dashboard/billing' }}
+                            >
+                                <ArrowUpRight className="h-3.5 w-3.5" />
+                                Mettre à niveau
+                            </Button>
+                        </div>
+                    </div>
+                )}
 
                 {/* Token expiration banner */}
                 {channelsWithTokenError.length > 0 && (

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -72,6 +72,7 @@ import type * as lib_encryption from "../lib/encryption.js";
 import type * as lib_encryptionMigration from "../lib/encryptionMigration.js";
 import type * as lib_permissions from "../lib/permissions.js";
 import type * as lib_planHelpers from "../lib/planHelpers.js";
+import type * as lib_planLimits from "../lib/planLimits.js";
 import type * as lib_rateLimits from "../lib/rateLimits.js";
 import type * as lib_stripePlans from "../lib/stripePlans.js";
 import type * as lib_templateBuilder from "../lib/templateBuilder.js";
@@ -181,6 +182,7 @@ declare const fullApi: ApiFromModules<{
   "lib/encryptionMigration": typeof lib_encryptionMigration;
   "lib/permissions": typeof lib_permissions;
   "lib/planHelpers": typeof lib_planHelpers;
+  "lib/planLimits": typeof lib_planLimits;
   "lib/rateLimits": typeof lib_rateLimits;
   "lib/stripePlans": typeof lib_stripePlans;
   "lib/templateBuilder": typeof lib_templateBuilder;

--- a/convex/broadcasts.test.ts
+++ b/convex/broadcasts.test.ts
@@ -51,6 +51,32 @@ describe("Broadcasts", () => {
             });
         });
 
+        // Default active WhatsApp channel — required by broadcasts.create plan gate
+        await t.run(async (ctx: any) => {
+            const wabaId = await ctx.db.insert("wabas", {
+                organizationId: orgId,
+                metaBusinessAccountId: "meta-default",
+                accessTokenRef: "token-default",
+                label: "Default WABA",
+                createdBy: userId,
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+            });
+            await ctx.db.insert("whatsappChannels", {
+                organizationId: orgId,
+                wabaId,
+                label: "Default Channel",
+                phoneNumberId: "phone-default",
+                displayPhoneNumber: "+221770000000",
+                webhookVerifyTokenRef: "verify-default",
+                isOrgDefault: true,
+                status: "active" as const,
+                createdBy: userId,
+                createdAt: Date.now(),
+                updatedAt: Date.now(),
+            });
+        });
+
         // Create tags
         const tags = await t.run(async (ctx: any) => {
             const t1 = await ctx.db.insert("tags", {

--- a/convex/broadcasts.ts
+++ b/convex/broadcasts.ts
@@ -157,6 +157,26 @@ export const create = mutation({
             throw new Error("Permission refusée: seuls les admins peuvent créer des broadcasts");
         }
 
+        // Plan gate: the org must have at least one active WhatsApp channel
+        // allowed by its current plan. Prevents creating broadcasts when all
+        // channels have been disabled after a downgrade.
+        const channels = await ctx.db
+            .query("whatsappChannels")
+            .withIndex("by_org", (q) => q.eq("organizationId", session.currentOrganizationId!))
+            .collect();
+        const hasActiveChannel = channels.some((c) => c.status === "active");
+        if (!hasActiveChannel) {
+            throw new Error(
+                "Aucun canal WhatsApp actif. Activez ou reconnectez un canal avant de créer un broadcast.",
+            );
+        }
+        if (args.whatsappChannelId) {
+            const target = channels.find((c) => c._id === args.whatsappChannelId);
+            if (!target || target.status !== "active") {
+                throw new Error("Le canal sélectionné n'est pas actif pour votre plan.");
+            }
+        }
+
         // Validation: scheduledAt doit être au moins 5 minutes dans le futur
         if (args.scheduledAt && args.scheduledAt <= Date.now() + 5 * 60 * 1000) {
             throw new Error("La date de planification doit être au moins 5 minutes dans le futur");

--- a/convex/invitations.ts
+++ b/convex/invitations.ts
@@ -4,6 +4,8 @@ import { requirePermission } from "./lib/auth";
 import { sendInvitationEmail } from "./lib/email";
 import { api, internal } from "./_generated/api";
 import { getAuthUserId } from "@convex-dev/auth/server";
+import { assertWithinLimit } from "./lib/planLimits";
+import { getMaxAgents, isUnlimited } from "./lib/planHelpers";
 
 // LIST PENDING INVITATIONS
 export const list = query({
@@ -176,6 +178,9 @@ export const createRecord = internalMutation({
             // We'll throw if direct auth fails.
             throw new Error("Could not resolve inviter");
         }
+
+        // Plan limit: block new invitations if the agent quota is already saturated.
+        await assertWithinLimit(ctx, args.organizationId, "agents");
 
         await ctx.db.insert("invitations", {
             organizationId: args.organizationId,
@@ -370,11 +375,28 @@ export const acceptLink = mutation({
         console.log(`[AcceptLink] Validating email. Invitation: '${invitationEmail}', User: '${userEmail}'`);
 
         if (invitationEmail !== userEmail) {
-            // In some cases user might use different email? 
+            // In some cases user might use different email?
             // Ideally we enforce it.
             console.error(`Email mismatch details: Invitation Email [${invitationEmail}] vs User Email [${userEmail}]`);
             // We throw the error but now we have logs
             throw new Error("Email mismatch");
+        }
+
+        // Plan limit re-check at acceptance time: count actual memberships only
+        // (the invite being accepted is itself counted as pending; we don't want
+        // to double-count it). Protects against concurrent acceptances when
+        // multiple PENDING invitations exceed quota.
+        const org = await ctx.db.get(invitation.organizationId);
+        if (!org) throw new Error("Organization not found");
+        const existingMemberships = await ctx.db
+            .query("memberships")
+            .withIndex("by_organization", (q) => q.eq("organizationId", invitation.organizationId))
+            .collect();
+        const maxAgents = await getMaxAgents(ctx, org.plan);
+        if (!isUnlimited(maxAgents) && existingMemberships.length >= maxAgents) {
+            throw new Error(
+                `Limite atteinte pour le plan ${org.plan} : agents (max ${maxAgents}). Supprimez un membre avant d'accepter cette invitation.`,
+            );
         }
 
         // Create Membership

--- a/convex/lib/planLimits.ts
+++ b/convex/lib/planLimits.ts
@@ -1,0 +1,104 @@
+/**
+ * Plan limits — helpers centralisés pour l'enforcement des quotas par plan.
+ *
+ * Source unique de vérité : table `plans` (voir planHelpers.ts).
+ * Convention : -1 signifie illimité.
+ */
+
+import type { QueryCtx, MutationCtx } from "../_generated/server";
+import type { Id } from "../_generated/dataModel";
+import { getPlanLimits, isUnlimited } from "./planHelpers";
+
+export type ResourceKind = "channels" | "agents" | "templates";
+
+/**
+ * Compte les canaux actifs (status != "disabled" & != "banned") d'une org.
+ */
+export async function countActiveChannels(
+    ctx: QueryCtx | MutationCtx,
+    organizationId: Id<"organizations">,
+): Promise<number> {
+    const channels = await ctx.db
+        .query("whatsappChannels")
+        .withIndex("by_org", (q) => q.eq("organizationId", organizationId))
+        .collect();
+    return channels.filter((c) => c.status !== "disabled" && c.status !== "banned").length;
+}
+
+/**
+ * Compte les memberships actifs + invitations PENDING (un seat en attente compte).
+ */
+export async function countActiveAgents(
+    ctx: QueryCtx | MutationCtx,
+    organizationId: Id<"organizations">,
+): Promise<number> {
+    const memberships = await ctx.db
+        .query("memberships")
+        .withIndex("by_organization", (q) => q.eq("organizationId", organizationId))
+        .collect();
+    const pendingInvites = await ctx.db
+        .query("invitations")
+        .withIndex("by_org_status", (q) =>
+            q.eq("organizationId", organizationId).eq("status", "PENDING"),
+        )
+        .collect();
+    return memberships.length + pendingInvites.length;
+}
+
+/**
+ * Compte les templates de l'org (tous statuts).
+ */
+export async function countTemplates(
+    ctx: QueryCtx | MutationCtx,
+    organizationId: Id<"organizations">,
+): Promise<number> {
+    const templates = await ctx.db
+        .query("templates")
+        .withIndex("by_organization", (q) => q.eq("organizationId", organizationId))
+        .collect();
+    return templates.length;
+}
+
+/**
+ * Vérifie qu'une ressource peut être créée sans dépasser la limite du plan.
+ * Throw une erreur explicite sinon.
+ */
+export async function assertWithinLimit(
+    ctx: QueryCtx | MutationCtx,
+    organizationId: Id<"organizations">,
+    kind: ResourceKind,
+): Promise<void> {
+    const org = await ctx.db.get(organizationId);
+    if (!org) throw new Error("Organization not found");
+
+    const limits = await getPlanLimits(ctx, org.plan);
+
+    let current: number;
+    let max: number;
+    let label: string;
+
+    switch (kind) {
+        case "channels":
+            current = await countActiveChannels(ctx, organizationId);
+            max = limits.maxWhatsappChannels;
+            label = "canaux WhatsApp";
+            break;
+        case "agents":
+            current = await countActiveAgents(ctx, organizationId);
+            max = limits.maxAgents;
+            label = "agents";
+            break;
+        case "templates":
+            current = await countTemplates(ctx, organizationId);
+            max = limits.maxTemplates;
+            label = "templates";
+            break;
+    }
+
+    if (isUnlimited(max)) return;
+    if (current >= max) {
+        throw new Error(
+            `Limite atteinte pour le plan ${org.plan} : ${label} (max ${max}). Passez à un plan supérieur pour en ajouter plus.`,
+        );
+    }
+}

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -780,7 +780,8 @@ export default defineSchema({
             v.literal("completed"),
             v.literal("failures"),
             v.literal("cancelled"),
-            v.literal("retry")
+            v.literal("retry"),
+            v.literal("paused")
         ),
         message: v.string(),
         createdAt: v.number(),
@@ -846,6 +847,11 @@ export default defineSchema({
             v.literal("disabled"),
             v.literal("banned"),
         ),
+        disabledReason: v.optional(v.union(
+            v.literal("manual"),
+            v.literal("plan_downgrade"),
+        )),
+        disabledAt: v.optional(v.number()),
         createdBy: v.id("users"),
         createdAt: v.number(),
         updatedAt: v.number(),

--- a/convex/stripe.ts
+++ b/convex/stripe.ts
@@ -1,6 +1,112 @@
 import { v } from "convex/values";
-import { internalMutation } from "./_generated/server";
+import { internalMutation, type MutationCtx } from "./_generated/server";
+import type { Id } from "./_generated/dataModel";
 import { planFromPriceId } from "./lib/stripePlans";
+import { getMaxChannels, isUnlimited } from "./lib/planHelpers";
+
+/**
+ * Applique la règle de cascade lors d'un downgrade de plan :
+ * désactive les canaux WhatsApp excédentaires en gardant en priorité
+ * le canal default/primary, puis les plus anciens.
+ *
+ * - status -> "disabled"
+ * - disabledReason -> "plan_downgrade"
+ * - disabledAt -> timestamp
+ *
+ * Met également en pause les broadcasts SCHEDULED liés aux canaux désactivés
+ * et notifie l'OWNER de l'organisation.
+ */
+async function enforceChannelDowngrade(
+    ctx: MutationCtx,
+    organizationId: Id<"organizations">,
+    newPlan: string,
+): Promise<number> {
+    const maxChannels = await getMaxChannels(ctx, newPlan);
+    if (isUnlimited(maxChannels)) return 0;
+
+    const channels = await ctx.db
+        .query("whatsappChannels")
+        .withIndex("by_org", (q) => q.eq("organizationId", organizationId))
+        .collect();
+
+    const activeChannels = channels.filter((c) => c.status !== "disabled" && c.status !== "banned");
+    if (activeChannels.length <= maxChannels) return 0;
+
+    // Règle déterministe : default/primary d'abord, puis les plus anciens
+    const sorted = [...activeChannels].sort((a, b) => {
+        if (a.isOrgDefault && !b.isOrgDefault) return -1;
+        if (!a.isOrgDefault && b.isOrgDefault) return 1;
+        return a.createdAt - b.createdAt;
+    });
+
+    const toKeep = sorted.slice(0, maxChannels);
+    const toDisable = sorted.slice(maxChannels);
+    const now = Date.now();
+    const disabledIds: Id<"whatsappChannels">[] = [];
+
+    for (const ch of toDisable) {
+        await ctx.db.patch(ch._id, {
+            status: "disabled",
+            disabledReason: "plan_downgrade",
+            disabledAt: now,
+            isOrgDefault: false,
+            updatedAt: now,
+        });
+        disabledIds.push(ch._id);
+    }
+
+    // Assurer qu'un canal default reste si la liste à garder en contient au moins un
+    const hasDefault = toKeep.some((c) => c.isOrgDefault);
+    if (!hasDefault && toKeep.length > 0) {
+        await ctx.db.patch(toKeep[0]._id, { isOrgDefault: true, updatedAt: now });
+    }
+
+    // Pause des broadcasts SCHEDULED qui ciblent les canaux désactivés
+    if (disabledIds.length > 0) {
+        const scheduled = await ctx.db
+            .query("broadcasts")
+            .withIndex("by_organization", (q) => q.eq("organizationId", organizationId))
+            .filter((q) => q.eq(q.field("status"), "SCHEDULED"))
+            .collect();
+        for (const b of scheduled) {
+            if (b.whatsappChannelId && disabledIds.includes(b.whatsappChannelId)) {
+                await ctx.db.patch(b._id, { status: "DRAFT", updatedAt: now });
+                await ctx.db.insert("broadcastActivities", {
+                    broadcastId: b._id,
+                    type: "paused",
+                    message: `Campagne dépubliée : canal désactivé après passage au plan ${newPlan}`,
+                    createdAt: now,
+                });
+            }
+        }
+    }
+
+    // Notifications — on notifie OWNER et ADMIN de l'organisation
+    const memberships = await ctx.db
+        .query("memberships")
+        .withIndex("by_organization", (q) => q.eq("organizationId", organizationId))
+        .collect();
+    for (const m of memberships) {
+        if (m.role !== "OWNER" && m.role !== "ADMIN") continue;
+        await ctx.db.insert("notifications", {
+            organizationId,
+            userId: m.userId,
+            type: "PLAN_DOWNGRADE",
+            title: "Canaux désactivés après changement de plan",
+            message: `Votre plan ${newPlan} autorise ${maxChannels} canal${maxChannels > 1 ? "aux" : ""}. ${disabledIds.length} canal${disabledIds.length > 1 ? "aux ont été désactivés" : " a été désactivé"}.`,
+            link: "/dashboard/channels",
+            isRead: false,
+            metadata: {
+                disabledChannelIds: disabledIds.map((id) => id.toString()),
+                newPlan,
+                maxChannels,
+            },
+            createdAt: now,
+        });
+    }
+
+    return disabledIds.length;
+}
 
 /**
  * Persist the Stripe customer ID immediately after creation.
@@ -57,6 +163,9 @@ export const handleCheckoutCompleted = internalMutation({
             },
             updatedAt: Date.now(),
         });
+
+        // Cascade enforcement si le nouveau plan a des limites inférieures
+        await enforceChannelDowngrade(ctx, org._id as Id<"organizations">, plan);
     },
 });
 
@@ -107,6 +216,8 @@ export const updateSubscription = internalMutation({
             },
             updatedAt: Date.now(),
         });
+
+        await enforceChannelDowngrade(ctx, org._id, plan);
     },
 });
 
@@ -140,5 +251,32 @@ export const cancelSubscription = internalMutation({
             },
             updatedAt: Date.now(),
         });
+
+        await enforceChannelDowngrade(ctx, org._id, "FREE");
+    },
+});
+
+/**
+ * Migration / régularisation rétroactive : applique la règle de cascade
+ * à toutes les organisations existantes. Utile après le déploiement
+ * pour désactiver les canaux excédentaires d'orgs déjà en dépassement.
+ */
+export const backfillPlanLimits = internalMutation({
+    args: {},
+    handler: async (ctx) => {
+        const orgs = await ctx.db.query("organizations").collect();
+        let totalDisabled = 0;
+        let orgsAffected = 0;
+        for (const org of orgs) {
+            const disabled = await enforceChannelDowngrade(ctx, org._id, org.plan);
+            if (disabled > 0) {
+                totalDisabled += disabled;
+                orgsAffected += 1;
+            }
+        }
+        console.log(
+            `[backfillPlanLimits] Désactivé ${totalDisabled} canaux dans ${orgsAffected} orgs`,
+        );
+        return { totalDisabled, orgsAffected };
     },
 });

--- a/convex/templates/mutations.ts
+++ b/convex/templates/mutations.ts
@@ -3,6 +3,7 @@ import { v } from "convex/values";
 import { mutation, internalMutation } from "../_generated/server";
 import { getAuthUserId } from "@convex-dev/auth/server";
 import { validateTemplate } from "../lib/templateValidation";
+import { assertWithinLimit } from "../lib/planLimits";
 import {
     headerValidator, buttonsValidator, carouselCardsValidator,
     catalogConfigValidator, listConfigValidator, locationConfigValidator,
@@ -41,6 +42,9 @@ export const create = mutation({
             .first();
 
         if (!session || !session.currentOrganizationId) throw new Error("No active organization");
+
+        // Plan limit: block template creation when quota is reached.
+        await assertWithinLimit(ctx, session.currentOrganizationId, "templates");
 
         // Validate
         const validation = validateTemplate(args);


### PR DESCRIPTION
## Summary
- Runtime enforcement: block new channels/agents/templates/broadcasts when the plan quota is reached via a centralized `assertWithinLimit()` helper (`convex/lib/planLimits.ts`).
- Cascade on Stripe subscription change: excess WhatsApp channels are auto-disabled (keep default/primary first, then oldest), SCHEDULED broadcasts on disabled channels revert to DRAFT, and OWNER/ADMIN receive a `PLAN_DOWNGRADE` notification.
- Schema: `whatsappChannels` gains `disabledReason` + `disabledAt`; `broadcastActivities.type` adds `"paused"`.
- `backfillPlanLimits` internal mutation for retroactive regularization; amber banner in `ChannelsSettings` when channels were disabled for plan downgrade with CTA to billing.

## Test plan
- [ ] `pnpx convex typecheck` and `pnpm build` green
- [ ] Existing vitest suite still 66/66 green
- [ ] Manually downgrade a Stripe subscription and verify excess channels are disabled, scheduled broadcasts paused, and notifications created
- [ ] Run `pnpx convex run stripe:backfillPlanLimits` on affected deployments to fix orgs already in overage