### PR TITLE
feat(onboarding): redesign wizard with adaptive card widths

### DIFF
--- a/app/(onboarding)/layout.tsx
+++ b/app/(onboarding)/layout.tsx
@@ -26,17 +26,15 @@ export default function OnboardingLayout({
 
     if (user === undefined) {
         return (
-            <div className="h-screen w-full flex items-center justify-center bg-gray-50">
+            <div className="h-screen w-full flex items-center justify-center bg-gray-50/50">
                 <Loader2 className="h-8 w-8 animate-spin text-green-600" />
             </div>
         );
     }
 
     return (
-        <div className="min-h-screen bg-gray-50 flex flex-col items-center justify-center p-4">
-            <div className="w-full max-w-2xl">
-                {children}
-            </div>
+        <div className="min-h-screen bg-gray-50/50">
+            {children}
         </div>
     );
 }

--- a/components/contacts/ContactList.tsx
+++ b/components/contacts/ContactList.tsx
@@ -628,13 +628,13 @@ export function ContactList({
                     <h1 className="text-xl sm:text-2xl font-bold text-gray-900 tracking-tight">
                         Contacts
                     </h1>
-                    <p className="text-sm text-gray-500 mt-0.5">
+                    <div className="text-sm text-gray-500 mt-0.5">
                         {isLoading ? (
                             <Skeleton className="h-4 w-32 inline-block" />
                         ) : (
                             <>{total} contact{total > 1 ? 's' : ''} au total</>
                         )}
-                    </p>
+                    </div>
                 </div>
 
                 <div className="flex items-center gap-2">

--- a/components/onboarding/OnboardingProgress.tsx
+++ b/components/onboarding/OnboardingProgress.tsx
@@ -12,10 +12,6 @@ import {
 import { cn } from '@/lib/utils';
 import type { OnboardingStep, OnboardingStepKey } from '@/lib/onboarding/steps';
 
-// ============================================
-// ICON MAP
-// ============================================
-
 const ICON_MAP: Record<string, LucideIcon> = {
     Building2,
     CreditCard,
@@ -24,19 +20,11 @@ const ICON_MAP: Record<string, LucideIcon> = {
     Circle,
 };
 
-// ============================================
-// TYPES
-// ============================================
-
 interface OnboardingProgressProps {
     steps: OnboardingStep[];
     currentStepKey: OnboardingStepKey;
     onStepClick: (stepKey: string) => void;
 }
-
-// ============================================
-// COMPONENT
-// ============================================
 
 export function OnboardingProgress({
     steps,
@@ -46,67 +34,64 @@ export function OnboardingProgress({
     const currentIndex = steps.findIndex((s) => s.key === currentStepKey);
 
     return (
-        <nav aria-label="Progression de l'onboarding" className="mb-8">
+        <nav aria-label="Progression de l'onboarding" className="mb-8 sm:mb-10">
             <ol className="flex items-start">
                 {steps.map((step, index) => {
                     const isCompleted = index < currentIndex;
                     const isCurrent = step.key === currentStepKey;
                     const isClickable = index < currentIndex;
 
-                    // Dynamic icon
                     const IconComponent = ICON_MAP[step.icon] || Circle;
 
                     return (
                         <li key={step.key} className="flex-1 flex flex-col items-center relative">
-                            {/* Connector Line (before) - positioned absolutely */}
                             {index > 0 && (
                                 <div
                                     className={cn(
-                                        'absolute top-6 right-1/2 h-0.5 w-1/2 -translate-y-1/2 transition-colors',
+                                        'absolute top-5 sm:top-6 right-1/2 h-[2px] w-1/2 -translate-y-1/2 transition-colors duration-300',
                                         index <= currentIndex ? 'bg-green-600' : 'bg-gray-200'
                                     )}
                                     aria-hidden="true"
                                 />
                             )}
 
-                            {/* Connector Line (after) - positioned absolutely */}
                             {index < steps.length - 1 && (
                                 <div
                                     className={cn(
-                                        'absolute top-6 left-1/2 h-0.5 w-1/2 -translate-y-1/2 transition-colors',
+                                        'absolute top-5 sm:top-6 left-1/2 h-[2px] w-1/2 -translate-y-1/2 transition-colors duration-300',
                                         index < currentIndex ? 'bg-green-600' : 'bg-gray-200'
                                     )}
                                     aria-hidden="true"
                                 />
                             )}
 
-                            {/* Step Circle */}
                             <button
                                 onClick={() => isClickable && onStepClick(step.key)}
                                 disabled={!isClickable}
                                 className={cn(
-                                    'relative z-10 flex h-12 w-12 items-center justify-center rounded-full border-2 transition-all',
-                                    isCompleted && 'border-green-600 bg-green-600 text-white',
-                                    isCurrent && 'border-green-600 bg-white text-green-600',
+                                    'relative z-10 flex h-10 w-10 sm:h-12 sm:w-12 items-center justify-center rounded-full border-2 transition-all duration-300',
+                                    isCompleted && 'border-green-600 bg-green-600 text-white shadow-sm shadow-green-900/20',
+                                    isCurrent && 'border-green-600 bg-white text-green-600 shadow-sm ring-4 ring-green-100',
                                     !isCompleted && !isCurrent && 'border-gray-200 bg-white text-gray-400',
-                                    isClickable && 'cursor-pointer hover:bg-green-50',
+                                    isClickable && 'cursor-pointer hover:bg-green-700 hover:border-green-700',
                                     !isClickable && 'cursor-default'
                                 )}
                                 aria-current={isCurrent ? 'step' : undefined}
                                 aria-label={`${step.title}${isCompleted ? ' (complété)' : ''}${isCurrent ? ' (étape actuelle)' : ''}`}
                             >
                                 {isCompleted ? (
-                                    <Check className="h-5 w-5" />
+                                    <Check className="h-4 w-4 sm:h-5 sm:w-5" strokeWidth={2.5} />
                                 ) : (
-                                    <IconComponent className="h-5 w-5" />
+                                    <IconComponent className="h-4 w-4 sm:h-5 sm:w-5" />
                                 )}
                             </button>
 
-                            {/* Step Label (centered under icon) */}
                             <span
                                 className={cn(
-                                    'mt-3 text-center text-xs font-medium max-w-[100px] hidden sm:block',
-                                    isCompleted || isCurrent ? 'text-gray-900' : 'text-gray-400'
+                                    'mt-2.5 sm:mt-3 text-center text-xs font-medium max-w-[100px] hidden sm:block transition-colors',
+                                    isCompleted && 'text-gray-900',
+                                    isCurrent && 'text-green-700',
+                                    !isCompleted && !isCurrent && 'text-gray-400'
                                 )}
                             >
                                 {step.title}

--- a/components/onboarding/OnboardingWizard.tsx
+++ b/components/onboarding/OnboardingWizard.tsx
@@ -15,10 +15,6 @@ import {
     getNextStep
 } from '@/lib/onboarding/steps';
 
-// ============================================
-// STEP COMPONENTS MAP
-// ============================================
-
 const STEP_COMPONENTS: Record<OnboardingStepKey, React.ComponentType<{ onComplete: () => void }>> = {
     BUSINESS_INFO: BusinessInfoStep,
     PLAN_SELECT: PlanSelectStep,
@@ -26,13 +22,16 @@ const STEP_COMPONENTS: Record<OnboardingStepKey, React.ComponentType<{ onComplet
     COMPLETED: CompletionStep,
 };
 
-// ============================================
-// ANIMATION VARIANTS
-// ============================================
+const STEP_CARD_WIDTH: Record<OnboardingStepKey, string> = {
+    BUSINESS_INFO: 'max-w-2xl',
+    PLAN_SELECT: 'max-w-5xl',
+    WHATSAPP_CONNECT: 'max-w-xl',
+    COMPLETED: 'max-w-3xl',
+};
 
 const stepVariants = {
     enter: (direction: number) => ({
-        x: direction > 0 ? 50 : -50,
+        x: direction > 0 ? 40 : -40,
         opacity: 0,
     }),
     center: {
@@ -40,14 +39,10 @@ const stepVariants = {
         opacity: 1,
     },
     exit: (direction: number) => ({
-        x: direction < 0 ? 50 : -50,
+        x: direction < 0 ? 40 : -40,
         opacity: 0,
     }),
 };
-
-// ============================================
-// COMPONENT
-// ============================================
 
 export function OnboardingWizard() {
     const [currentStepKey, setCurrentStepKey] = useState<OnboardingStepKey>('BUSINESS_INFO');
@@ -65,8 +60,6 @@ export function OnboardingWizard() {
     };
 
     const handleStepClick = (stepKey: string) => {
-        // Basic navigation logic: allow going back or to completed steps
-        // For now, simpler implementation: verify order
         const targetStep = getStepByKey(stepKey as OnboardingStepKey);
         const current = getStepByKey(currentStepKey);
 
@@ -78,24 +71,34 @@ export function OnboardingWizard() {
         }
     };
 
-    return (
-        <div className="w-full max-w-3xl mx-auto px-3 sm:px-4 py-6 sm:py-8">
-            {/* Progress Bar */}
-            <OnboardingProgress
-                steps={ONBOARDING_STEPS}
-                currentStepKey={currentStepKey}
-                onStepClick={handleStepClick}
-            />
+    const cardWidth = STEP_CARD_WIDTH[currentStepKey];
 
-            {/* Page Header */}
-            <div className="text-center mb-8">
-                <h1 className="text-xl sm:text-2xl font-bold text-gray-900">{currentStep?.title}</h1>
-                <p className="mt-2 text-gray-500">{currentStep?.description}</p>
+    return (
+        <div className="w-full px-3 sm:px-6 lg:px-10 py-6 sm:py-8 lg:py-12">
+            <div className="w-full max-w-5xl mx-auto">
+                <OnboardingProgress
+                    steps={ONBOARDING_STEPS}
+                    currentStepKey={currentStepKey}
+                    onStepClick={handleStepClick}
+                />
+
+                <div className="text-center mb-6 sm:mb-8">
+                    <h1 className="text-xl sm:text-2xl font-bold text-gray-900 tracking-tight">
+                        {currentStep?.title}
+                    </h1>
+                    <p className="mt-1.5 text-sm text-gray-500">
+                        {currentStep?.description}
+                    </p>
+                </div>
             </div>
 
-            {/* Step Content */}
-            <Card className="border-none shadow-xl bg-white/80 backdrop-blur-sm">
-                <CardContent className="p-6 sm:p-8">
+            <motion.div
+                layout
+                transition={{ duration: 0.3, ease: [0.32, 0.72, 0, 1] }}
+                className={`w-full ${cardWidth} mx-auto`}
+            >
+                <Card className="border border-gray-100 shadow-sm bg-white">
+                    <CardContent className="p-5 sm:p-7 lg:p-9">
                     <AnimatePresence mode="wait" custom={direction}>
                         <motion.div
                             key={currentStepKey}
@@ -104,13 +107,14 @@ export function OnboardingWizard() {
                             initial="enter"
                             animate="center"
                             exit="exit"
-                            transition={{ duration: 0.3, ease: 'easeOut' }}
+                            transition={{ duration: 0.25, ease: [0.32, 0.72, 0, 1] }}
                         >
                             <StepComponent onComplete={handleNext} />
                         </motion.div>
                     </AnimatePresence>
-                </CardContent>
-            </Card>
+                    </CardContent>
+                </Card>
+            </motion.div>
         </div>
     );
 }

--- a/components/onboarding/steps/BusinessInfoStep.tsx
+++ b/components/onboarding/steps/BusinessInfoStep.tsx
@@ -3,10 +3,11 @@
 import { useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { Loader2, ArrowRight, Globe, CheckIcon, XIcon } from 'lucide-react';
+import { Loader2, ArrowRight, Globe, CheckIcon, XIcon, AlertCircle } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
+import { Alert, AlertDescription } from '@/components/ui/alert';
 import {
     Form,
     FormControl,
@@ -23,6 +24,7 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
+import { cn } from '@/lib/utils';
 
 import {
     businessInfoSchema,
@@ -56,7 +58,6 @@ export function BusinessInfoStep({ onComplete }: BusinessInfoStepProps) {
 
     const createOrg = useMutation(api.organizations.create);
 
-    // Slug check logic
     const slug = form.watch('slug');
     const checkSlug = useQuery(api.organizations.checkSlug, slug && slug.length >= 3 ? { slug } : "skip");
     const [slugStatus, setSlugStatus] = useState<'checking' | 'available' | 'taken' | null>(null);
@@ -108,24 +109,28 @@ export function BusinessInfoStep({ onComplete }: BusinessInfoStepProps) {
         }
     }
 
+    const inputClass = "h-11 rounded-xl border-gray-200 bg-gray-50 focus-visible:bg-white focus-visible:border-green-500 focus-visible:ring-green-500/20 transition-colors";
+    const selectTriggerClass = "h-11 rounded-xl border-gray-200 bg-gray-50 data-[state=open]:bg-white hover:bg-white focus:bg-white focus:border-green-500 focus:ring-green-500/20 transition-colors";
+
     return (
         <Form {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-                {/* Business Name */}
+            <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-5">
                 <FormField
                     control={form.control}
                     name="businessName"
                     render={({ field }) => (
                         <FormItem>
-                            <FormLabel>Nom de l&apos;entreprise *</FormLabel>
+                            <FormLabel className="text-sm font-medium text-gray-700">
+                                Nom de l&apos;entreprise <span className="text-green-600">*</span>
+                            </FormLabel>
                             <FormControl>
                                 <Input
                                     placeholder="Ma Super Entreprise"
                                     disabled={isLoading}
+                                    className={inputClass}
                                     {...field}
                                     onChange={(e) => {
                                         field.onChange(e);
-                                        // Auto-generate slug if not manually edited
                                         const slug = e.target.value
                                             .toLowerCase()
                                             .replace(/\s+/g, '-')
@@ -134,7 +139,7 @@ export function BusinessInfoStep({ onComplete }: BusinessInfoStepProps) {
                                     }}
                                 />
                             </FormControl>
-                            <FormDescription>
+                            <FormDescription className="text-xs text-gray-500">
                                 Le nom qui sera affiché dans vos messages WhatsApp
                             </FormDescription>
                             <FormMessage />
@@ -142,19 +147,20 @@ export function BusinessInfoStep({ onComplete }: BusinessInfoStepProps) {
                     )}
                 />
 
-                {/* Slug (subdomain) */}
                 <FormField
                     control={form.control}
                     name="slug"
                     render={({ field }) => (
                         <FormItem>
-                            <FormLabel>Identifiant unique (slug) *</FormLabel>
+                            <FormLabel className="text-sm font-medium text-gray-700">
+                                Identifiant unique (slug) <span className="text-green-600">*</span>
+                            </FormLabel>
                             <FormControl>
                                 <div className="relative">
                                     <Input
                                         placeholder="mon-entreprise"
                                         disabled={isLoading}
-                                        className="pr-10"
+                                        className={cn(inputClass, 'pr-10')}
                                         {...field}
                                         onChange={(e) => {
                                             const value = e.target.value
@@ -164,31 +170,32 @@ export function BusinessInfoStep({ onComplete }: BusinessInfoStepProps) {
                                             field.onChange(value);
                                         }}
                                     />
-                                    <Globe className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                                    <Globe className="absolute right-3.5 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-400" />
                                 </div>
                             </FormControl>
                             {field.value && (
-                                <div className={`flex items-center gap-2 mt-2 p-2 rounded-md border text-xs
-                                    ${slugStatus === 'available' ? 'bg-green-50 border-green-100 text-green-700' : ''}
-                                    ${slugStatus === 'taken' ? 'bg-red-50 border-red-100 text-red-700' : ''}
-                                    ${slugStatus === 'checking' ? 'bg-gray-50 border-gray-100 text-gray-500' : ''}
-                                `}>
-                                    {slugStatus === 'checking' && <Loader2 className="h-3 w-3 animate-spin" />}
-                                    {slugStatus === 'available' && <CheckIcon className="h-3 w-3" />}
-                                    {slugStatus === 'taken' && <XIcon className="h-3 w-3" />}
+                                <div className={cn(
+                                    'flex items-center gap-2 mt-2 px-3 py-2 rounded-lg border text-xs transition-colors',
+                                    slugStatus === 'available' && 'bg-green-50 border-green-200 text-green-700',
+                                    slugStatus === 'taken' && 'bg-red-50 border-red-200 text-red-700',
+                                    slugStatus === 'checking' && 'bg-gray-50 border-gray-200 text-gray-500',
+                                )}>
+                                    {slugStatus === 'checking' && <Loader2 className="h-3.5 w-3.5 animate-spin" />}
+                                    {slugStatus === 'available' && <CheckIcon className="h-3.5 w-3.5" strokeWidth={2.5} />}
+                                    {slugStatus === 'taken' && <XIcon className="h-3.5 w-3.5" strokeWidth={2.5} />}
 
                                     <span className="font-medium">
                                         {field.value}.jokko.com
                                     </span>
 
-                                    <span className="ml-auto">
+                                    <span className="ml-auto font-medium">
                                         {slugStatus === 'checking' && 'Vérification...'}
                                         {slugStatus === 'available' && 'Disponible'}
                                         {slugStatus === 'taken' && 'Déjà pris'}
                                     </span>
                                 </div>
                             )}
-                            <FormDescription>
+                            <FormDescription className="text-xs text-gray-500">
                                 Votre URL d&apos;accès au dashboard.
                             </FormDescription>
                             <FormMessage />
@@ -196,20 +203,21 @@ export function BusinessInfoStep({ onComplete }: BusinessInfoStepProps) {
                     )}
                 />
 
-                {/* Business Sector */}
                 <FormField
                     control={form.control}
                     name="businessSector"
                     render={({ field }) => (
                         <FormItem>
-                            <FormLabel>Secteur d&apos;activité *</FormLabel>
+                            <FormLabel className="text-sm font-medium text-gray-700">
+                                Secteur d&apos;activité <span className="text-green-600">*</span>
+                            </FormLabel>
                             <Select
                                 onValueChange={field.onChange}
                                 defaultValue={field.value}
                                 disabled={isLoading}
                             >
                                 <FormControl>
-                                    <SelectTrigger>
+                                    <SelectTrigger className={selectTriggerClass}>
                                         <SelectValue placeholder="Sélectionnez votre secteur" />
                                     </SelectTrigger>
                                 </FormControl>
@@ -217,7 +225,7 @@ export function BusinessInfoStep({ onComplete }: BusinessInfoStepProps) {
                                     {BUSINESS_SECTORS.map((sector) => (
                                         <SelectItem key={sector.value} value={sector.value}>
                                             <div className="flex items-center gap-2">
-                                                <sector.icon className="h-4 w-4 text-muted-foreground" />
+                                                <sector.icon className="h-4 w-4 text-gray-500" />
                                                 <span>{sector.label}</span>
                                             </div>
                                         </SelectItem>
@@ -229,62 +237,68 @@ export function BusinessInfoStep({ onComplete }: BusinessInfoStepProps) {
                     )}
                 />
 
-                {/* Website */}
-                <FormField
-                    control={form.control}
-                    name="businessWebsite"
-                    render={({ field }) => (
-                        <FormItem>
-                            <FormLabel>Site web (optionnel)</FormLabel>
-                            <FormControl>
-                                <Input
-                                    type="url"
-                                    placeholder="https://www.example.com"
-                                    disabled={isLoading}
-                                    {...field}
-                                />
-                            </FormControl>
-                            <FormMessage />
-                        </FormItem>
-                    )}
-                />
-
-                {/* Phone */}
-                <FormField
-                    control={form.control}
-                    name="businessPhone"
-                    render={({ field }) => (
-                        <FormItem>
-                            <FormLabel>Téléphone (optionnel)</FormLabel>
-                            <FormControl>
-                                <Input
-                                    type="tel"
-                                    placeholder="+221 77 123 45 67"
-                                    disabled={isLoading}
-                                    {...field}
-                                />
-                            </FormControl>
-                            <FormMessage />
-                        </FormItem>
-                    )}
-                />
-
-                {/* Timezone & Locale row */}
                 <div className="grid gap-4 sm:grid-cols-2">
-                    {/* Timezone */}
+                    <FormField
+                        control={form.control}
+                        name="businessWebsite"
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel className="text-sm font-medium text-gray-700">
+                                    Site web
+                                </FormLabel>
+                                <FormControl>
+                                    <Input
+                                        type="url"
+                                        placeholder="https://www.example.com"
+                                        disabled={isLoading}
+                                        className={inputClass}
+                                        {...field}
+                                    />
+                                </FormControl>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+
+                    <FormField
+                        control={form.control}
+                        name="businessPhone"
+                        render={({ field }) => (
+                            <FormItem>
+                                <FormLabel className="text-sm font-medium text-gray-700">
+                                    Téléphone
+                                </FormLabel>
+                                <FormControl>
+                                    <Input
+                                        type="tel"
+                                        placeholder="+221 77 123 45 67"
+                                        disabled={isLoading}
+                                        className={inputClass}
+                                        {...field}
+                                    />
+                                </FormControl>
+                                <FormMessage />
+                            </FormItem>
+                        )}
+                    />
+                </div>
+
+                <div className="grid gap-4 sm:grid-cols-2">
                     <FormField
                         control={form.control}
                         name="timezone"
                         render={({ field }) => (
                             <FormItem>
-                                <FormLabel>Fuseau horaire</FormLabel>
+                                <FormLabel className="text-sm font-medium text-gray-700">
+                                    Fuseau horaire
+                                </FormLabel>
                                 <Select
                                     onValueChange={field.onChange}
                                     defaultValue={field.value}
                                     disabled={isLoading}
                                 >
                                     <FormControl>
-                                        <SelectTrigger>
+                                        <SelectTrigger className={selectTriggerClass}>
                                             <SelectValue placeholder="Sélectionnez" />
                                         </SelectTrigger>
                                     </FormControl>
@@ -301,20 +315,21 @@ export function BusinessInfoStep({ onComplete }: BusinessInfoStepProps) {
                         )}
                     />
 
-                    {/* Locale */}
                     <FormField
                         control={form.control}
                         name="locale"
                         render={({ field }) => (
                             <FormItem>
-                                <FormLabel>Langue</FormLabel>
+                                <FormLabel className="text-sm font-medium text-gray-700">
+                                    Langue
+                                </FormLabel>
                                 <Select
                                     onValueChange={field.onChange}
                                     defaultValue={field.value}
                                     disabled={isLoading}
                                 >
                                     <FormControl>
-                                        <SelectTrigger>
+                                        <SelectTrigger className={selectTriggerClass}>
                                             <SelectValue placeholder="Sélectionnez" />
                                         </SelectTrigger>
                                     </FormControl>
@@ -332,22 +347,25 @@ export function BusinessInfoStep({ onComplete }: BusinessInfoStepProps) {
                     />
                 </div>
 
-                {/* Error */}
-                {error && <p className="text-sm text-red-600 bg-red-50 p-3 rounded-md">{error}</p>}
+                {error && (
+                    <Alert variant="destructive" className="border-red-200 bg-red-50">
+                        <AlertCircle className="h-4 w-4" />
+                        <AlertDescription className="text-red-700">{error}</AlertDescription>
+                    </Alert>
+                )}
 
-                {/* Submit */}
                 <Button
                     type="submit"
                     size="lg"
                     disabled={isLoading || slugStatus === 'taken' || slugStatus === 'checking'}
-                    className="w-full h-12 bg-gradient-to-r from-green-600 to-green-700 hover:from-green-700 hover:to-green-800 text-white font-semibold rounded-xl shadow-lg shadow-green-600/25 hover:shadow-green-600/40 transition-all duration-300 group"
+                    className="w-full h-12 bg-gradient-to-r from-green-600 to-green-700 hover:from-green-700 hover:to-green-800 text-white font-semibold rounded-xl shadow-sm hover:shadow-md transition-all group"
                 >
                     {isLoading ? (
                         <Loader2 className="mr-2 h-5 w-5 animate-spin" />
                     ) : (
                         <>
                             Continuer
-                            <ArrowRight className="ml-2 h-5 w-5 group-hover:translate-x-1 transition-transform" />
+                            <ArrowRight className="ml-2 h-5 w-5 group-hover:translate-x-0.5 transition-transform" />
                         </>
                     )}
                 </Button>

--- a/components/onboarding/steps/CompletionStep.tsx
+++ b/components/onboarding/steps/CompletionStep.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { motion } from 'framer-motion';
 import {
     CheckCircle,
     MessageSquare,
@@ -55,7 +56,7 @@ const QUICK_ACTIONS = [
     },
 ];
 
-export function CompletionStep({ onComplete }: CompletionStepProps) {
+export function CompletionStep({}: CompletionStepProps) {
     const router = useRouter();
     const { currentOrg } = useCurrentOrg();
     const { currentPlan } = usePlanLimits();
@@ -63,7 +64,6 @@ export function CompletionStep({ onComplete }: CompletionStepProps) {
     const createCheckout = useAction(api.stripe_actions.createCheckoutSession);
     const [checkoutLoading, setCheckoutLoading] = useState(false);
 
-    // Safety net: ensure onboarding is marked complete
     useEffect(() => {
         completeOnboarding().catch(() => {});
     }, [completeOnboarding]);
@@ -91,33 +91,38 @@ export function CompletionStep({ onComplete }: CompletionStepProps) {
     };
 
     return (
-        <div className="space-y-8 py-2">
-            {/* Success header */}
+        <div className="space-y-7">
             <div className="text-center space-y-3">
-                <div className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-green-100">
-                    <CheckCircle className="w-8 h-8 text-green-600" />
+                <motion.div
+                    initial={{ scale: 0.6, opacity: 0 }}
+                    animate={{ scale: 1, opacity: 1 }}
+                    transition={{ type: 'spring', stiffness: 200, damping: 16, delay: 0.05 }}
+                    className="inline-flex items-center justify-center w-16 h-16 rounded-full bg-green-100 ring-8 ring-green-50"
+                >
+                    <CheckCircle className="w-8 h-8 text-green-600" strokeWidth={2.5} />
+                </motion.div>
+                <div>
+                    <h2 className="text-xl sm:text-2xl font-bold text-gray-900 tracking-tight">
+                        {currentOrg?.name ? `${currentOrg.name} est prêt !` : 'Tout est prêt !'}
+                    </h2>
+                    <p className="mt-1.5 text-sm text-gray-500 max-w-md mx-auto">
+                        Votre espace Jokko est configuré. Voici comment commencer.
+                    </p>
                 </div>
-                <h2 className="text-2xl font-bold text-gray-900">
-                    {currentOrg?.name ? `${currentOrg.name} est prêt !` : 'Tout est prêt !'}
-                </h2>
-                <p className="text-gray-500 text-sm max-w-md mx-auto">
-                    Votre espace Jokko est configuré. Voici comment commencer.
-                </p>
             </div>
 
-            {/* Plan badge */}
             {currentPlan && (
                 <div className="flex justify-center">
                     <div className={cn(
-                        'inline-flex items-center gap-2 rounded-full px-4 py-2 border text-sm font-medium',
+                        'inline-flex items-center gap-2 rounded-full px-3.5 py-1.5 border text-xs font-medium',
                         isPaidPlan
                             ? 'bg-green-50 border-green-200 text-green-700'
                             : 'bg-gray-50 border-gray-200 text-gray-600'
                     )}>
-                        <Sparkles className="h-4 w-4" />
+                        <Sparkles className="h-3.5 w-3.5" />
                         Plan {currentPlan.name}
                         {isPaidPlan && currentPlan.monthlyPriceFCFA > 0 && (
-                            <span className="text-xs opacity-75">
+                            <span className="opacity-75">
                                 — {new Intl.NumberFormat('fr-FR').format(
                                     billingInterval === 'year'
                                         ? currentPlan.yearlyMonthlyPriceFCFA
@@ -129,16 +134,15 @@ export function CompletionStep({ onComplete }: CompletionStepProps) {
                 </div>
             )}
 
-            {/* Stripe CTA for paid plans */}
             {isPaidPlan && !currentOrg?.stripe?.status && (
-                <div className="rounded-xl border border-green-200 bg-green-50/50 p-4 text-center space-y-3">
-                    <p className="text-sm text-green-800">
+                <div className="rounded-xl border border-green-100 bg-green-50/50 p-5 text-center space-y-3">
+                    <p className="text-sm text-green-900">
                         Activez votre abonnement pour débloquer toutes les fonctionnalités du plan <strong>{currentPlan?.name}</strong>.
                     </p>
                     <Button
                         onClick={handleActivateSubscription}
                         disabled={checkoutLoading}
-                        className="bg-gradient-to-r from-[#14532d] to-[#059669] hover:from-[#0f4024] hover:to-[#047857] text-white rounded-xl shadow-lg"
+                        className="h-10 bg-gradient-to-r from-[#14532d] to-[#059669] hover:from-[#0f4024] hover:to-[#047857] text-white rounded-xl shadow-sm hover:shadow-md transition-all"
                     >
                         {checkoutLoading ? (
                             <Loader2 className="h-4 w-4 mr-2 animate-spin" />
@@ -153,37 +157,40 @@ export function CompletionStep({ onComplete }: CompletionStepProps) {
                 </div>
             )}
 
-            {/* Quick actions grid */}
-            <div className="grid grid-cols-2 gap-3">
-                {QUICK_ACTIONS.map((action) => {
+            <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                {QUICK_ACTIONS.map((action, index) => {
                     const Icon = action.icon;
                     return (
-                        <button
+                        <motion.button
                             key={action.href}
+                            initial={{ opacity: 0, y: 8 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ duration: 0.25, delay: 0.1 + index * 0.05 }}
                             onClick={() => router.push(action.href)}
-                            className="group flex flex-col items-center gap-2 rounded-xl border border-gray-200 bg-white p-4 text-center hover:border-green-200 hover:shadow-md transition-all duration-200"
+                            className="group flex flex-col items-start gap-2 rounded-xl border border-gray-200 bg-white p-4 text-left hover:border-green-200 hover:bg-green-50/30 hover:shadow-sm transition-all"
                         >
                             <div className={cn(
-                                'flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br shadow-md group-hover:scale-110 transition-transform',
+                                'flex h-9 w-9 items-center justify-center rounded-lg bg-gradient-to-br shadow-sm shadow-green-900/20 group-hover:scale-105 transition-transform',
                                 action.gradient
                             )}>
-                                <Icon className="h-5 w-5 text-white" />
+                                <Icon className="h-4 w-4 text-white" />
                             </div>
-                            <span className="text-sm font-medium text-gray-900">{action.title}</span>
-                            <span className="text-[11px] text-gray-500 leading-tight">{action.description}</span>
-                        </button>
+                            <div>
+                                <div className="text-sm font-semibold text-gray-900">{action.title}</div>
+                                <div className="text-[11px] text-gray-500 leading-tight mt-0.5">{action.description}</div>
+                            </div>
+                        </motion.button>
                     );
                 })}
             </div>
 
-            {/* Go to dashboard */}
             <Button
                 onClick={() => router.push('/dashboard')}
                 size="lg"
-                className="w-full h-12 bg-gradient-to-r from-green-600 to-green-700 hover:from-green-700 hover:to-green-800 text-white font-semibold rounded-xl shadow-lg shadow-green-600/25 hover:shadow-green-600/40 transition-all duration-300 group"
+                className="w-full h-12 bg-gradient-to-r from-green-600 to-green-700 hover:from-green-700 hover:to-green-800 text-white font-semibold rounded-xl shadow-sm hover:shadow-md transition-all group"
             >
                 Accéder au dashboard
-                <ArrowRight className="ml-2 h-5 w-5 group-hover:translate-x-1 transition-transform" />
+                <ArrowRight className="ml-2 h-5 w-5 group-hover:translate-x-0.5 transition-transform" />
             </Button>
         </div>
     );

--- a/components/onboarding/steps/PlanSelectStep.tsx
+++ b/components/onboarding/steps/PlanSelectStep.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button';
 import { Loader2, Check, Zap, Store, Building2, ArrowRight } from 'lucide-react';
 import { useMutation } from 'convex/react';
@@ -18,17 +19,14 @@ const PLAN_CONFIG = {
     STARTER: {
         icon: Zap,
         gradient: 'from-[#14532d] to-[#059669]',
-        ring: 'ring-emerald-500/10 border-emerald-300',
     },
     BUSINESS: {
         icon: Store,
         gradient: 'from-[#166534] to-[#0d9488]',
-        ring: 'ring-teal-500/10 border-teal-300',
     },
     PRO: {
         icon: Building2,
         gradient: 'from-[#15803d] to-[#10b981]',
-        ring: 'ring-green-500/10 border-green-300',
     },
 } as const;
 
@@ -94,7 +92,6 @@ export function PlanSelectStep({ onComplete }: PlanSelectStepProps) {
 
     return (
         <div className="space-y-6">
-            {/* Billing interval toggle */}
             <div className="flex justify-center">
                 <div className="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-gray-50 p-1">
                     <button
@@ -123,9 +120,8 @@ export function PlanSelectStep({ onComplete }: PlanSelectStepProps) {
                 </div>
             </div>
 
-            {/* Plan cards */}
-            <div className="grid gap-4 md:grid-cols-3">
-                {displayPlans.map((plan) => {
+            <div className="grid gap-5 lg:gap-6 md:grid-cols-3">
+                {displayPlans.map((plan, index) => {
                     const Icon = plan.icon;
                     const isSelected = selectedPlan === plan.key;
                     const price = billingInterval === 'month'
@@ -133,91 +129,87 @@ export function PlanSelectStep({ onComplete }: PlanSelectStepProps) {
                         : plan.priceYearlyMonthly;
 
                     return (
-                        <button
+                        <motion.button
                             key={plan.key}
+                            initial={{ opacity: 0, y: 12 }}
+                            animate={{ opacity: 1, y: 0 }}
+                            transition={{ duration: 0.25, delay: index * 0.06, ease: [0.32, 0.72, 0, 1] }}
                             onClick={() => setSelectedPlan(plan.key)}
                             disabled={isLoading}
                             className={cn(
-                                'relative flex flex-col rounded-xl border-2 p-5 text-left transition-all duration-200',
+                                'relative flex flex-col rounded-2xl border p-6 lg:p-7 text-left transition-all duration-200 bg-white',
                                 isSelected
-                                    ? `ring-4 ${plan.ring} shadow-lg`
-                                    : 'border-gray-200 hover:border-gray-300 hover:shadow-md',
-                                plan.popular && !isSelected && 'border-gray-300'
+                                    ? 'border-green-500 ring-4 ring-green-100 shadow-sm'
+                                    : 'border-gray-200 hover:border-green-200 hover:bg-green-50/30 hover:shadow-sm',
                             )}
                         >
-                            {/* Popular badge */}
                             {plan.popular && (
-                                <span className="absolute -top-2.5 left-1/2 -translate-x-1/2 rounded-full bg-gradient-to-r from-[#14532d] to-[#059669] px-3 py-0.5 text-[10px] font-bold text-white shadow-sm">
+                                <span className="absolute -top-3 left-1/2 -translate-x-1/2 rounded-full bg-gradient-to-r from-[#14532d] to-[#059669] px-3.5 py-1 text-[11px] font-bold text-white shadow-sm shadow-green-900/20">
                                     Recommandé
                                 </span>
                             )}
 
-                            {/* Icon + Name */}
-                            <div className="flex items-center gap-3 mb-3">
+                            <div className="flex items-center gap-3 mb-5">
                                 <div className={cn(
-                                    'flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-to-br shadow-lg',
+                                    'flex h-12 w-12 items-center justify-center rounded-xl bg-gradient-to-br shadow-sm shadow-green-900/20',
                                     plan.gradient
                                 )}>
-                                    <Icon className="h-5 w-5 text-white" />
+                                    <Icon className="h-6 w-6 text-white" />
                                 </div>
-                                <div>
-                                    <h3 className="font-semibold text-gray-900">{plan.name}</h3>
-                                    <p className="text-[11px] text-gray-500">{plan.description}</p>
+                                <div className="min-w-0">
+                                    <h3 className="text-base font-semibold text-gray-900">{plan.name}</h3>
+                                    <p className="text-xs text-gray-500 truncate">{plan.description}</p>
                                 </div>
                             </div>
 
-                            {/* Price */}
-                            <div className="mb-4">
-                                <span className="text-2xl font-bold text-gray-900">
+                            <div className="mb-5">
+                                <span className="text-3xl font-bold text-gray-900 tracking-tight">
                                     {new Intl.NumberFormat('fr-FR').format(price)}
                                 </span>
-                                <span className="text-sm text-gray-500 ml-1">F CFA/mois</span>
+                                <span className="text-sm text-gray-500 ml-1">F CFA</span>
+                                <div className="text-xs text-gray-500 mt-0.5">par mois</div>
                             </div>
 
-                            {/* Features */}
-                            <ul className="space-y-2 flex-1">
+                            <ul className="space-y-2.5 flex-1">
                                 {plan.features.map((feature, i) => (
                                     <li key={i} className="flex items-start gap-2 text-sm text-gray-600">
-                                        <Check className="h-4 w-4 shrink-0 text-green-600 mt-0.5" />
+                                        <Check className="h-4 w-4 shrink-0 text-green-600 mt-0.5" strokeWidth={2.5} />
                                         <span>{feature}</span>
                                     </li>
                                 ))}
                             </ul>
 
-                            {/* Selection indicator */}
                             {isSelected && (
-                                <div className="mt-4 flex items-center justify-center gap-1.5 rounded-lg bg-green-50 py-2 text-sm font-medium text-green-700">
-                                    <Check className="h-4 w-4" />
+                                <div className="mt-5 flex items-center justify-center gap-1.5 rounded-lg bg-green-50 border border-green-100 py-2 text-sm font-semibold text-green-700">
+                                    <Check className="h-4 w-4" strokeWidth={2.5} />
                                     Sélectionné
                                 </div>
                             )}
-                        </button>
+                        </motion.button>
                     );
                 })}
             </div>
 
-            {/* CTA */}
             <Button
                 onClick={() => handleSelectPlan(selectedPlan)}
                 disabled={isLoading}
                 size="lg"
-                className="w-full h-12 bg-gradient-to-r from-green-600 to-green-700 hover:from-green-700 hover:to-green-800 text-white font-semibold rounded-xl shadow-lg shadow-green-600/25 hover:shadow-green-600/40 transition-all duration-300 group"
+                className="w-full h-12 bg-gradient-to-r from-green-600 to-green-700 hover:from-green-700 hover:to-green-800 text-white font-semibold rounded-xl shadow-sm hover:shadow-md transition-all group"
             >
                 {isLoading ? (
                     <Loader2 className="mr-2 h-5 w-5 animate-spin" />
                 ) : (
                     <>
                         Continuer avec {displayPlans.find(p => p.key === selectedPlan)?.name}
-                        <ArrowRight className="ml-2 h-5 w-5 group-hover:translate-x-1 transition-transform" />
+                        <ArrowRight className="ml-2 h-5 w-5 group-hover:translate-x-0.5 transition-transform" />
                     </>
                 )}
             </Button>
 
-            {/* Free option */}
             <button
                 onClick={() => handleSelectPlan('FREE')}
                 disabled={isLoading}
-                className="w-full text-center text-sm text-gray-500 hover:text-gray-700 transition-colors py-2"
+                className="w-full text-center text-sm text-gray-500 hover:text-gray-900 transition-colors py-1"
             >
                 Continuer gratuitement avec le plan Free
             </button>

--- a/components/onboarding/steps/WhatsAppConnectStep.tsx
+++ b/components/onboarding/steps/WhatsAppConnectStep.tsx
@@ -1,14 +1,17 @@
 'use client';
 
 import { useState } from 'react';
+import { motion } from 'framer-motion';
 import { Button } from '@/components/ui/button';
-import { Loader2, AlertCircle, SkipForward } from 'lucide-react';
+import { Loader2, AlertCircle, SkipForward, MessageCircle } from 'lucide-react';
 import { useMutation, useAction } from 'convex/react';
 import { api } from '@/convex/_generated/api';
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { Label } from "@/components/ui/label"
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
+import { Badge } from "@/components/ui/badge"
 import { useFacebookSDK } from "@/hooks/useFacebookSDK";
+import { cn } from '@/lib/utils';
 
 interface WhatsAppConnectStepProps {
     onComplete: () => void;
@@ -26,15 +29,12 @@ export function WhatsAppConnectStep({ onComplete }: WhatsAppConnectStepProps) {
     const [status, setStatus] = useState<'IDLE' | 'FETCHING' | 'SELECTING' | 'SAVING' | 'SKIPPING' | 'ERROR'>('IDLE');
     const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
-    // Facebook SDK
     const { isReady: fbReady, login: fbLogin } = useFacebookSDK();
 
-    // Data State
     const [accessToken, setAccessToken] = useState<string | null>(null);
     const [phoneNumbers, setPhoneNumbers] = useState<WhatsAppNumber[]>([]);
     const [selectedPhoneId, setSelectedPhoneId] = useState<string | null>(null);
 
-    // Convex Actions
     const completeOnboarding = useMutation(api.users.completeOnboarding);
     const fetchNumbers = useAction(api.whatsapp.fetchWhatsAppPhoneNumbers);
     const addChannel = useAction(api.whatsapp.addChannel);
@@ -49,7 +49,6 @@ export function WhatsAppConnectStep({ onComplete }: WhatsAppConnectStepProps) {
         }
     };
 
-    // Step 1: Fetch Numbers
     async function handleFetchNumbers(token: string) {
         setStatus('FETCHING');
         setAccessToken(token);
@@ -72,7 +71,6 @@ export function WhatsAppConnectStep({ onComplete }: WhatsAppConnectStepProps) {
         }
     }
 
-    // Step 2: Finalize — use addChannel which handles token exchange + WABA + channel creation
     async function handleConfirmSelection() {
         if (!accessToken || !selectedPhoneId) return;
 
@@ -97,7 +95,6 @@ export function WhatsAppConnectStep({ onComplete }: WhatsAppConnectStepProps) {
         }
     }
 
-    // Skip: complete onboarding without WhatsApp
     async function handleSkip() {
         setStatus('SKIPPING');
         try {
@@ -109,40 +106,73 @@ export function WhatsAppConnectStep({ onComplete }: WhatsAppConnectStepProps) {
         }
     }
 
-    // ==========================================
-    // RENDER
-    // ==========================================
+    const qualityColor = (rating: string) => {
+        const r = rating.toUpperCase();
+        if (r === 'GREEN' || r === 'HIGH') return 'bg-green-100 text-green-700 border-green-200';
+        if (r === 'YELLOW' || r === 'MEDIUM') return 'bg-amber-100 text-amber-700 border-amber-200';
+        if (r === 'RED' || r === 'LOW') return 'bg-red-100 text-red-700 border-red-200';
+        return 'bg-gray-100 text-gray-600 border-gray-200';
+    };
 
-    // Show selection UI if selecting OR saving
     if (status === 'SELECTING' || status === 'SAVING') {
         return (
-            <div className="space-y-6">
+            <div className="space-y-5">
                 <div className="text-center">
-                    <h3 className="text-xl font-semibold text-gray-900">Choisissez votre numéro</h3>
-                    <p className="text-sm text-gray-500">
-                        Nous avons trouvé plusieurs numéros associés à ce compte Business.
-                        Lequel souhaitez-vous connecter à Jokko ?
+                    <h3 className="text-base font-semibold text-gray-900">Choisissez votre numéro</h3>
+                    <p className="mt-1 text-sm text-gray-500">
+                        Sélectionnez le numéro WhatsApp Business à connecter à Jokko.
                     </p>
                 </div>
 
-                <div className="max-h-[300px] overflow-y-auto border rounded-md p-4 bg-gray-50">
-                    <RadioGroup value={selectedPhoneId || ''} onValueChange={setSelectedPhoneId}>
-                        {phoneNumbers.map((phone) => (
-                            <div key={phone.id} className="flex items-center space-x-2 mb-2 last:mb-0">
-                                <RadioGroupItem value={phone.id} id={phone.id} />
-                                <Label htmlFor={phone.id} className="flex flex-col cursor-pointer w-full p-3 rounded-lg border bg-white hover:border-green-500 transition-colors">
-                                    <span className="font-semibold text-gray-900">{phone.verified_name || 'Numéro sans nom'}</span>
-                                    <span className="text-sm text-gray-500">{phone.display_phone_number}</span>
-                                    <span className="text-xs text-green-600 mt-1">Qualité: {phone.quality_rating}</span>
+                <RadioGroup
+                    value={selectedPhoneId || ''}
+                    onValueChange={setSelectedPhoneId}
+                    className="space-y-2 max-h-[320px] overflow-y-auto pr-1"
+                >
+                    {phoneNumbers.map((phone, index) => {
+                        const isSelected = selectedPhoneId === phone.id;
+                        return (
+                            <motion.div
+                                key={phone.id}
+                                initial={{ opacity: 0, y: 6 }}
+                                animate={{ opacity: 1, y: 0 }}
+                                transition={{ duration: 0.2, delay: index * 0.04 }}
+                            >
+                                <Label
+                                    htmlFor={phone.id}
+                                    className={cn(
+                                        'flex items-center gap-3 cursor-pointer p-3.5 rounded-xl border bg-white transition-all',
+                                        isSelected
+                                            ? 'border-green-500 ring-4 ring-green-100 shadow-sm'
+                                            : 'border-gray-200 hover:border-green-200 hover:bg-green-50/30'
+                                    )}
+                                >
+                                    <RadioGroupItem value={phone.id} id={phone.id} className="mt-0.5" />
+                                    <div className="flex-1 min-w-0">
+                                        <div className="flex items-center justify-between gap-2">
+                                            <span className="text-sm font-semibold text-gray-900 truncate">
+                                                {phone.verified_name || 'Numéro sans nom'}
+                                            </span>
+                                            <Badge
+                                                variant="outline"
+                                                className={cn('text-[10px] font-medium border', qualityColor(phone.quality_rating))}
+                                            >
+                                                {phone.quality_rating}
+                                            </Badge>
+                                        </div>
+                                        <span className="block text-xs text-gray-500 mt-0.5 font-mono">
+                                            {phone.display_phone_number}
+                                        </span>
+                                    </div>
                                 </Label>
-                            </div>
-                        ))}
-                    </RadioGroup>
-                </div>
+                            </motion.div>
+                        );
+                    })}
+                </RadioGroup>
 
                 <Button
                     onClick={handleConfirmSelection}
-                    className="w-full bg-green-600 hover:bg-green-700 text-white"
+                    className="w-full h-12 bg-gradient-to-r from-green-600 to-green-700 hover:from-green-700 hover:to-green-800 text-white font-semibold rounded-xl shadow-sm hover:shadow-md transition-all"
                     disabled={status === 'SAVING'}
                 >
                     {status === 'SAVING' ? (
@@ -155,68 +185,74 @@ export function WhatsAppConnectStep({ onComplete }: WhatsAppConnectStepProps) {
                 <button
                     onClick={handleSkip}
                     disabled={status === 'SAVING'}
-                    className="w-full text-center text-sm text-gray-500 hover:text-gray-700 transition-colors py-1"
+                    className="w-full text-center text-sm text-gray-500 hover:text-gray-900 transition-colors py-1"
                 >
                     Passer cette étape
                 </button>
             </div>
-        )
+        );
     }
 
     return (
-        <div className="space-y-6 text-center">
-            <div className="bg-green-50 p-6 rounded-xl border border-green-100">
-                <h3 className="text-lg font-semibold text-green-900 mb-2">Connexion WhatsApp Business</h3>
-                <p className="text-green-700 text-sm mb-4">
+        <div className="space-y-6">
+            <div className="rounded-xl border border-green-100 bg-green-50/50 p-6 sm:p-8 text-center">
+                <div className="mx-auto mb-4 flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br from-[#25D366] to-[#128C7E] shadow-sm shadow-green-900/20">
+                    <MessageCircle className="h-7 w-7 text-white" />
+                </div>
+
+                <h3 className="text-base sm:text-lg font-semibold text-gray-900">
+                    Connexion WhatsApp Business
+                </h3>
+                <p className="mt-1.5 text-sm text-gray-600 max-w-sm mx-auto">
                     Utilisez votre compte Facebook pour connecter votre numéro WhatsApp Business en quelques clics.
                 </p>
 
                 {errorMessage && (
-                    <Alert variant="destructive" className="mb-4 text-left">
+                    <Alert variant="destructive" className="mt-5 border-red-200 bg-red-50 text-left">
                         <AlertCircle className="h-4 w-4" />
-                        <AlertTitle>Erreur</AlertTitle>
-                        <AlertDescription>{errorMessage}</AlertDescription>
+                        <AlertTitle className="text-red-800">Erreur</AlertTitle>
+                        <AlertDescription className="text-red-700">{errorMessage}</AlertDescription>
                     </Alert>
                 )}
 
-                <div className="flex justify-center p-4">
-                    <Button
-                        onClick={launchWhatsAppSignup}
-                        disabled={!fbReady || status === 'FETCHING' || status === 'SKIPPING'}
-                        size="lg"
-                        className="h-12 bg-gradient-to-r from-[#25D366] to-[#128C7E] hover:from-[#20bd5a] hover:to-[#0f7a6e] text-white font-semibold rounded-xl shadow-lg shadow-green-600/25 hover:shadow-green-600/40 transition-all duration-300 flex items-center gap-2"
-                    >
-                        {status === 'FETCHING' || !fbReady ? (
-                            <Loader2 className="w-5 h-5 animate-spin" />
-                        ) : (
-                            <svg className="w-5 h-5 fill-current" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
-                            </svg>
-                        )}
-                        {status === 'FETCHING' ? "Récupération..." : !fbReady ? "Chargement..." : "Connecter WhatsApp Business"}
-                    </Button>
-                </div>
-                <p className="text-xs text-gray-500 mt-2">
+                <Button
+                    onClick={launchWhatsAppSignup}
+                    disabled={!fbReady || status === 'FETCHING' || status === 'SKIPPING'}
+                    size="lg"
+                    className="mt-5 h-12 w-full sm:w-auto px-6 bg-gradient-to-r from-[#25D366] to-[#128C7E] hover:from-[#20bd5a] hover:to-[#0f7a6e] text-white font-semibold rounded-xl shadow-sm hover:shadow-md transition-all"
+                >
+                    {status === 'FETCHING' || !fbReady ? (
+                        <Loader2 className="w-5 h-5 animate-spin" />
+                    ) : (
+                        <svg className="w-5 h-5 fill-current" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                            <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z" />
+                        </svg>
+                    )}
+                    {status === 'FETCHING' ? "Récupération..." : !fbReady ? "Chargement..." : "Connecter WhatsApp Business"}
+                </Button>
+
+                <p className="mt-3 text-[11px] text-gray-500">
                     Une fenêtre popup va s&apos;ouvrir. Assurez-vous de désactiver votre bloqueur de popups.
                 </p>
             </div>
 
-            {/* Skip option */}
-            <button
-                onClick={handleSkip}
-                disabled={status === 'FETCHING' || status === 'SKIPPING'}
-                className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-700 transition-colors py-2"
-            >
-                {status === 'SKIPPING' ? (
-                    <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                ) : (
-                    <SkipForward className="w-3.5 h-3.5" />
-                )}
-                Passer cette étape — je connecterai WhatsApp plus tard
-            </button>
-            <p className="text-[11px] text-gray-400">
-                Vous pourrez connecter WhatsApp depuis Paramètres &gt; Canaux à tout moment.
-            </p>
+            <div className="text-center">
+                <button
+                    onClick={handleSkip}
+                    disabled={status === 'FETCHING' || status === 'SKIPPING'}
+                    className="inline-flex items-center gap-1.5 text-sm text-gray-500 hover:text-gray-900 transition-colors py-1"
+                >
+                    {status === 'SKIPPING' ? (
+                        <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                    ) : (
+                        <SkipForward className="w-3.5 h-3.5" />
+                    )}
+                    Passer cette étape — je connecterai WhatsApp plus tard
+                </button>
+                <p className="mt-1 text-[11px] text-gray-400">
+                    Vous pourrez connecter WhatsApp depuis Paramètres &gt; Canaux à tout moment.
+                </p>
+            </div>
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- Align onboarding visuals with dashboard style: `bg-gray-50/50`, solid cards, `rounded-xl` inputs, animated progress stepper, staggered framer-motion transitions.
- Card width now adapts per step (business `max-w-2xl` / plans `max-w-5xl` / whatsapp `max-w-xl` / completion `max-w-3xl`) with a `layout` transition between steps for smooth width morphing.
- Polish: bigger plan cards (`rounded-2xl`, larger icons/typography), Badge/Alert components for slug status and errors, 4-col quick-actions grid on completion, spring success icon.
- Drive-by: fix hydration error in `ContactList` header (`<p>` wrapping a `<Skeleton>` div).

## Test plan
- [ ] Sign up a fresh user and walk through all 4 onboarding steps
- [ ] Verify the Card morphs width smoothly between steps
- [ ] Check slug availability feedback (typing, available, taken)
- [ ] Switch billing interval and confirm plan card refreshes
- [ ] Confirm skip path on WhatsApp step completes onboarding
- [ ] Ensure contacts page no longer throws the hydration warning