### PR TITLE
fix(onboarding): block subdomain redirect until onboarding is complete

### DIFF
--- a/app/dashboard/layout.tsx
+++ b/app/dashboard/layout.tsx
@@ -56,9 +56,10 @@ export default function DashboardLayout({
         }
     }, [sessionData, user, ensureSession, sessionRetries, router]);
 
-    // 3. Subdomain Redirect
+    // 3. Subdomain Redirect — only after onboarding is complete
     useEffect(() => {
         if (!sessionData?.organization?.slug) return;
+        if (user?.onboardingCompleted !== true) return;
 
         const slug = sessionData.organization.slug;
         const hostname = window.location.hostname;
@@ -83,7 +84,7 @@ export default function DashboardLayout({
                 window.location.href = newUrl;
             }
         }
-    }, [sessionData]);
+    }, [sessionData, user]);
 
     // -----------------------------------------------------
     // RENDERING STATES


### PR DESCRIPTION
## Summary
- Bloque la redirection vers le sous-domaine de l'org dans `DashboardLayout` tant que `user.onboardingCompleted !== true`.
- Corrige une race condition où un utilisateur ayant créé une org au step 1 du wizard puis quitté était renvoyé sur le sous-domaine au lieu de `/onboarding` au retour.

## Test plan
- [ ] Démarrer l'onboarding, créer une org au step BusinessInfo, fermer l'onglet.
- [ ] Revenir sur `/dashboard` : doit rediriger vers `/onboarding` (root domain), pas vers `slug.localhost:1000`.
- [ ] Terminer l'onboarding : la redirection sous-domaine doit reprendre normalement.