### PR TITLE
fix(ci): use pnpm build:web after monorepo split

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm build
+      - run: pnpm build:web
 
   # e2e:
   #   name: Playwright E2E


### PR DESCRIPTION
CI Build step was calling `pnpm build` but root package.json now has `build:web` (monorepo split). Main is red on #53 merge commit — this unblocks it.